### PR TITLE
[FIX] Delete CR 에러 해결

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,12 @@ export default tseslint.config([
       prettier,
     },
     rules: {
-      'prettier/prettier': 'error', // Prettier 규칙을 ESLint에서 강제
+      'prettier/prettier': [
+        'error',
+        {
+          endOfLine: 'auto',
+        },
+      ],
     },
     languageOptions: {
       ecmaVersion: 2020,


### PR DESCRIPTION
## 🧾 관련 이슈
close : #3 


## 🔍 구현한 내용
- ESLint 설정에서 prettier/prettier 규칙에 `endOfLine: auto` 옵션을 추가
- Windows(Mac) 환경 차이로 발생하던 `Delete CR` 줄 끝 문자 에러를 방지
- 코드 로직 변경 없음 (설정 파일만 수정)



## 📸 스크린샷(선택사항)
원래 아래와 같이 Delete CR 에러가 발생했는데 이 부분을 해결하였습니다.
<img width="514" height="295" alt="스크린샷 2025-09-19 223606" src="https://github.com/user-attachments/assets/3483e483-722f-42bd-803f-395e9fdad8c7" />



## 🙌 리뷰어에게
해당 브랜치에서 실행해보시고 여전히 에러가 발생하는지 확인 부탁드립니다.