### PR TITLE
[REFACTOR] 디자인 토큰 수정

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -8,9 +8,9 @@
   --font-sans: Pretendard, system-ui, sans-serif;
 
   /* Colors */
-  --color-black: #0f1114;
+  --color-black: #090a0c;
   --color-white: #ffffff;
-  --color-background: #0f1114;
+  --color-background: #090a0c;
 
   --color-grey-900: #16181d;
   --color-grey-800: #1d2025;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -53,7 +53,7 @@
       rgba(0, 0, 0, 0.85) 100%
     ),
     linear-gradient(90deg, #c2d2ef 0%, #afc7e9 12%, #c2eff2 50%, #cff7dc 87.5%, #f1fce2 100%);
-  --gradient-graphic: linear-gradient(243.42deg, #d5ff7a -3.15%, #80bdff 98.08%);
+  --gradient-graphic: linear-gradient(243.42deg, #95c8ff -3.15%, #e0ff9e 98.08%);
   --gradient-text: linear-gradient(90deg, #f2ffd5 0%, #b2ccff 128.68%);
   --gradient-container: radial-gradient(100% 100% at 49.85% 100%, #3a4140 0%, #1d2025 100%);
   --gradient-stroke: linear-gradient(

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -61,9 +61,13 @@
     rgba(255, 255, 255, 0.25) 0%,
     rgba(255, 255, 255, 0) 100%
   );
-  --gradient-graphic-light: var(
-    --Gradient-Graphic_light,
-    linear-gradient(90deg, #f1fce2 0%, #cff7dc 12.5%, #c2eff2 50%, #afc7e9 88%, #c2d2ef 100%)
+  --gradient-graphic-light: linear-gradient(
+    90deg,
+    #f1fce2 0%,
+    #cff7dc 12.5%,
+    #c2eff2 50%,
+    #afc7e9 88%,
+    #c2d2ef 100%
   );
 
   /* Spacing */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -61,6 +61,10 @@
     rgba(255, 255, 255, 0.25) 0%,
     rgba(255, 255, 255, 0) 100%
   );
+  --gradient-graphic-light: var(
+    --Gradient-Graphic_light,
+    linear-gradient(90deg, #f1fce2 0%, #cff7dc 12.5%, #c2eff2 50%, #afc7e9 88%, #c2d2ef 100%)
+  );
 
   /* Spacing */
   --spacing-0: 0px;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -13,6 +13,10 @@
     background-image: var(--gradient-graphic);
   }
 
+  .graphic-gradient-light {
+    background-image: var(--gradient-graphic-light);
+  }
+
   .text-gradient {
     background-image: var(--gradient-text);
     /* 


### PR DESCRIPTION
## 🧾 관련 이슈
close : #5 


## 🔍 구현한 내용

- Black(BG) 컬러의 색상을 #090A0C으로 변경
- Graphic Gradient_light 컬러 추가
- Graphic Gradient 컬러 변경 (바뀐 컬러는 #95C8FF, #E0FF9E)



## 📸 스크린샷(선택사항)
<img width="930" height="186" alt="스크린샷 2025-09-21 231633" src="https://github.com/user-attachments/assets/745dc3a9-37f8-49cb-a6c5-e3e07d98c992" />





## 🙌 리뷰어에게
해당 브랜치에서 실행해보시고 이상 있으시면 알려주세요.
