### PR TITLE
[UI] 어드민 페이지 세미나 카드 조회 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.9.1",
+        "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^4.1.13"
       },
       "devDependencies": {
@@ -3501,6 +3502,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-4.0.0.tgz",
+      "integrity": "sha512-gobtvVcThB2Dxhy0EeYSS1RKQJ5baDFkamkhwBvzvevwX6L4XQfpZ3me9s25Ss1ecFVT5jPYJ50n+7xTBJG9WQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.1",
+    "tailwind-scrollbar-hide": "^4.0.0",
     "tailwindcss": "^4.1.13"
   },
   "devDependencies": {

--- a/src/components/admin/seminar-manage/SeminarCard.tsx
+++ b/src/components/admin/seminar-manage/SeminarCard.tsx
@@ -1,0 +1,49 @@
+import { Link } from 'react-router-dom';
+import { formatDate } from '../../../utils/formatDate';
+
+interface Seminar {
+  id: number;
+  title: string;
+  date: string;
+  location: string;
+  topic: string;
+}
+
+interface SeminarCardProps {
+  seminar: Seminar;
+}
+
+const SeminarCard: React.FC<SeminarCardProps> = ({ seminar }) => {
+  return (
+    <Link to={`/admin/seminars/${seminar.id}`}>
+      <div className="bg-grey-700 rounded-lg p-5 cursor-pointer transition-shadow hover:shadow-2xl shadow-grey-500">
+        {/* 세미나 정보 */}
+        <h2 className="heading-2-bold mb-3 text-center">{seminar.title}</h2>
+
+        <div className="flex space-x-5">
+          {/* 이미지 */}
+          <div className="w-[250px] h-[200px] bg-grey-100 rounded-md"></div>
+
+          <div className="flex flex-col mt-[16px] flex-1 min-w-0">
+            <div className="mb-[16px]">
+              <p className="body-2-semibold mb-[8px] text-grey-300">일정</p>
+              <div className="caption-semibold">{formatDate(seminar.date)}</div>
+            </div>
+            <div className="mb-[16px]">
+              <p className="body-2-semibold mb-[8px] text-grey-300">장소</p>
+              <div className="caption-semibold ">{seminar.location}</div>
+            </div>
+            <div className="mb-[16px]">
+              <p className="body-2-semibold mb-[8px] text-grey-300">주제</p>
+              <div className="caption-semibold w-full overflow-hidden whitespace-nowrap text-ellipsis">
+                {seminar.topic}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default SeminarCard;

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import 'pretendard/dist/web/static/pretendard.css';
 @import 'tailwindcss';
+@import 'tailwind-scrollbar-hide/v4';
 @import './styles/theme.css';
 @import './styles/utilities.css';
 @import './styles/components.css';

--- a/src/layouts/admin/AdminLayout.tsx
+++ b/src/layouts/admin/AdminLayout.tsx
@@ -6,7 +6,7 @@ const AdminLayout: React.FC = () => {
   return (
     <div className="flex h-screen bg-background">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto p-8">
+      <main className="flex-1 overflow-y-auto p-8 scrollbar-hide">
         <Outlet />
       </main>
     </div>

--- a/src/pages/admin/seminar-manage/Cards.tsx
+++ b/src/pages/admin/seminar-manage/Cards.tsx
@@ -1,7 +1,76 @@
+import { Link } from 'react-router-dom';
+import SeminarCard from '../../../components/admin/seminar-manage/SeminarCard';
+
+// mock data
+const mockSeminars = [
+  {
+    id: 10,
+    title: '제 10회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피ㄴㅇㅁㄴㅇㅁㄴㅇㄴㅁ',
+  },
+  {
+    id: 9,
+    title: '제 9회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
+  },
+  {
+    id: 8,
+    title: '제 8회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
+  },
+  {
+    id: 7,
+    title: '제 7회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
+  },
+  {
+    id: 6,
+    title: '제 6회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
+  },
+  {
+    id: 5,
+    title: '제 5회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
+  },
+  {
+    id: 4,
+    title: '제 4회 Devtalk Seminar',
+    date: '2025-10-04T19:00:00',
+    location: '가나다라마바사',
+    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
+  },
+];
+
 const Cards = () => {
   return (
-    <div>
-      <h1>세미나카드조회</h1>
+    <div className="max-w-6xl py-[60px] pl-[30px]">
+      {/* 헤더 */}
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="heading-1-bold text-white">세미나 카드 조회</h1>
+        <Link className="heading-3-semibold text-green-300 cursor-pointer" to="/admin/seminars/add">
+          추가하기
+        </Link>
+      </div>
+
+      {/* 세미나 카드 */}
+      <div className="grid grid-cols-2 gap-10">
+        {mockSeminars.map((seminar) => (
+          <SeminarCard key={seminar.id} seminar={seminar} />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,23 @@
+export const formatDate = (isoString: string) => {
+  const date = new Date(isoString);
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  const week = ['일', '월', '화', '수', '목', '금', '토'];
+  const dayOfWeek = week[date.getDay()];
+
+  // 12시간제
+  let hours = date.getHours();
+  const minutes = date.getMinutes();
+  const ampm = hours >= 12 ? '오후' : '오전';
+
+  hours %= 12;
+  hours = hours || 12; // 0시는 12시로 표시
+
+  // 분이 한 자리 수일 경우 앞에 0을 붙여줌
+  const paddedMinutes = String(minutes).padStart(2, '0');
+
+  return `${year}. ${month}. ${day} (${dayOfWeek}) ${ampm} ${hours}:${paddedMinutes}`;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,5 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar-hide')],
 };


### PR DESCRIPTION
## 🧾 관련 이슈
close : #23 


## 🔍 구현한 내용

어드민의 세미나 카드 조회 페이지 구현했습니다.


## 📸 스크린샷(선택사항)

<img width="1706" height="921" alt="image" src="https://github.com/user-attachments/assets/2abc0b37-0d87-4998-90b8-3af4ae9dd9cc" />




## 🙌 리뷰어에게

- tailwind-scrollbar-hide 설치했습니다. (merge 후 디코에  남기겠습니다)
- 리뷰시 index.css의 #root 부분 주석 처리와 App.tsx에 AdminLayout 추가 부탁드립니다.
- 와이어프레임을 기준으로 구현해서 수정할 부분 있으면 편하게 말씀해 주세요!
- 카드에 hover시 shadow 스타일을 적용했는데, 어드민 페이지인만큼 깔끔하게 하는게 좋을지 shadow 정도는 괜찮을지 의견 있으시면 말씀해주세요.