### PR TITLE
[FEAT] 레이아웃 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import UserLayout from './layouts/user/UserLayout';
+import AdminLayout from './layouts/admin/AdminLayout';
 import Home from './pages/user/home/Home';
 import SeminarApply from './pages/user/seminar/Apply';
 import SeminarHome from './pages/user/seminar/Home';
@@ -27,29 +29,35 @@ function App() {
     <Router>
       <Routes>
         {/* 유저 페이지 */}
-        <Route path="/" element={<Home />} />
-        <Route path="/seminar/apply" element={<SeminarApply />} />
-        <Route path="/seminar" element={<SeminarHome />} />
-        <Route path="/seminar/:id" element={<SeminarDetail />} />
-        <Route path="/seminar/live" element={<SeminarLive />} />
-        <Route path="/seminar/review" element={<SeminarReview />} />
-        <Route path="/speakers" element={<SpeakersList />} />
-        <Route path="/speakers/:id" element={<SpeakersDetail />} />
-        <Route path="/notice" element={<NoticeHome />} />
-        <Route path="/notice/qna" element={<NoticeQna />} />
-        <Route path="/notice/inquiry" element={<NoticeInquiry />} />
+        <Route element={<UserLayout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/seminar/apply" element={<SeminarApply />} />
+          <Route path="/seminar" element={<SeminarHome />} />
+          <Route path="/seminar/:id" element={<SeminarDetail />} />
+          <Route path="/seminar/live" element={<SeminarLive />} />
+          <Route path="/seminar/review" element={<SeminarReview />} />
+          <Route path="/speakers" element={<SpeakersList />} />
+          <Route path="/speakers/:id" element={<SpeakersDetail />} />
+          <Route path="/notice" element={<NoticeHome />} />
+          <Route path="/notice/qna" element={<NoticeQna />} />
+          <Route path="/notice/inquiry" element={<NoticeInquiry />} />
+        </Route>
+
+        {/* 관리자 로그인 (사이드바 등 레이아웃 제외) */}
+        <Route path="/admin/login" element={<AdminLogin />} />
 
         {/* 관리자 페이지 */}
-        <Route path="/admin/login" element={<AdminLogin />} />
-        <Route path="/admin/home/promo" element={<PromoImage />} />
-        <Route path="/admin/home/links" element={<Links />} />
-        <Route path="/admin/home/reviews" element={<Reviews />} />
-        <Route path="/admin/seminars" element={<SeminarCards />} />
-        <Route path="/admin/seminars/:id" element={<SeminarManageDetail />} />
-        <Route path="/admin/seminars/add" element={<SeminarAdd />} />
-        <Route path="/admin/seminars/applicants" element={<SeminarApplicants />} />
-        <Route path="/admin/seminar-live/attendance" element={<Attendance />} />
-        <Route path="/admin/admin-accounts" element={<Accounts />} />
+        <Route element={<AdminLayout />}>
+          <Route path="/admin/home/promo" element={<PromoImage />} />
+          <Route path="/admin/home/links" element={<Links />} />
+          <Route path="/admin/home/reviews" element={<Reviews />} />
+          <Route path="/admin/seminars" element={<SeminarCards />} />
+          <Route path="/admin/seminars/:id" element={<SeminarManageDetail />} />
+          <Route path="/admin/seminars/add" element={<SeminarAdd />} />
+          <Route path="/admin/seminars/applicants" element={<SeminarApplicants />} />
+          <Route path="/admin/seminar-live/attendance" element={<Attendance />} />
+          <Route path="/admin/admin-accounts" element={<Accounts />} />
+        </Route>
       </Routes>
     </Router>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,4 @@
   body {
     @apply bg-background text-white font-sans;
   }
-
-  #root {
-    @apply w-full max-w-[375px] mx-auto;
-  }
 }

--- a/src/layouts/user/UserLayout.tsx
+++ b/src/layouts/user/UserLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const AdminLayout: React.FC = () => {
+  return (
+    <div className="w-full max-w-[375px] mx-auto min-h-screen bg-background">
+      <Outlet />
+    </div>
+  );
+};
+
+export default AdminLayout;


### PR DESCRIPTION
## 🧾 관련 이슈
close : #36 


## 🔍 구현한 내용
- 레이아웃을 설정하였습니다.
- AdminLayout은 구현되어 있어 UserLayout만 추가로 만들었고, 이에 맞춰 App.tsx 라우팅 구조 변경하였습니다!
- 또, index.css에 있던 #root 제거하고 각 레이아웃 따라서 너비 설정되도록 하였습니다.


## 📸 스크린샷(선택사항)
기본 경로(유저 레이아웃 적용) : 375px 적용
<img width="927" height="397" alt="image" src="https://github.com/user-attachments/assets/f05e5f52-f6f7-40d7-ae44-7509d0eb8f85" />

어드민 로그인 경로: 데스크탑 뷰 (사이드바 적용되지 않도록 레이아웃 감싸지 않음)
<img width="1293" height="817" alt="image" src="https://github.com/user-attachments/assets/0ce97db0-bb02-4172-b0e6-b0d9d94e5caa" />

어드민 경로(어드민 레이아웃 적용): 데스크탑 뷰 
<img width="1272" height="753" alt="image" src="https://github.com/user-attachments/assets/d716735b-34a6-45dd-87f6-f01726a82387" />


## 🙌 리뷰어에게
- 경로별로 레이아웃 지정 잘 되어있는지 확인 부탁드립니다. 
- 레이아웃에서 수정사항 있는 경우 말씀해주세요!