### PR TITLE
[UI] 어드민 홈 화면 관리 - 홍보 사진 관리 화면 구현

### DIFF
--- a/src/pages/admin/home-manage/PromoImage.tsx
+++ b/src/pages/admin/home-manage/PromoImage.tsx
@@ -1,7 +1,7 @@
 const PromoImage = () => {
   return (
     <div>
-      <h1>홍보사진관리</h1>
+      <h1 className="mt-60 ml-60 heading-1-bold text-white">홍보 사진 관리</h1>
     </div>
   );
 };

--- a/src/pages/admin/home-manage/PromoImage.tsx
+++ b/src/pages/admin/home-manage/PromoImage.tsx
@@ -1,7 +1,19 @@
+import AdminImageUpload from '../../../components/admin/upload/AdminImageUpload';
+
 const PromoImage = () => {
   return (
-    <div>
-      <h1 className="mt-60 ml-60 heading-1-bold text-white">홍보 사진 관리</h1>
+    <div className="space-y-40 ml-60 mr-60 mb-[175px]">
+      <h1 className="mt-60 heading-1-bold text-white">홍보 사진 관리</h1>
+      <AdminImageUpload
+        title="Devtalk 소개 사진"
+        onUpload={(files) => console.log('이미지 업로드:', files)}
+        onRemove={(index) => console.log('이미지 삭제:', index)}
+      />
+      <AdminImageUpload
+        title="이전 세미나 보러가기 사진"
+        onUpload={(files) => console.log('이미지 업로드:', files)}
+        onRemove={(index) => console.log('이미지 삭제:', index)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 🧾 관련 이슈
close : #20 
## 🔍 구현한 내용
어드민 페이지 - 홈 화면 관리 - 홍보 사진 관리 화면 UI 구현
(기존에 만든 이미지 업로드 컴포넌트 이용)
## 📸 스크린샷(선택사항)

<img width="1117" height="813" alt="스크린샷 2025-09-25 오후 11 16 45" src="https://github.com/user-attachments/assets/bd593022-070d-43e3-a5b1-981b3e81800e" />
내부 컴포넌트들은 화면 크기에 따라 양옆 여백을 유지하며 크기가 일정 사이즈까지 줄어들었다 커질 수 있습니다.

## 🙌 리뷰어에게

<img width="991" height="727" alt="image" src="https://github.com/user-attachments/assets/5dd2037f-eb4a-4c23-91f8-27ad776237bf" />

@BeJunseok AdminLayout에 `<main className="flex-1 overflow-y-auto p-8">` 이렇게 설정되어있어 8px 패딩이 생기는데 혹시 일부러 이렇게 설정하신걸까요?? 

다른 부분 문제 없는지 확인부탁드립니다.!