### PR TITLE
[UI] 어드민 페이지 상세 정보 폼 컴포넌트 구현

### DIFF
--- a/src/components/admin/SeminarManage/FormField.tsx
+++ b/src/components/admin/SeminarManage/FormField.tsx
@@ -1,0 +1,43 @@
+interface FormFieldProps {
+  label: string;
+  id: string;
+  placeholder: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  error?: string;
+  maxLength?: number;
+}
+
+const FormField: React.FC<FormFieldProps> = ({
+  label,
+  id,
+  placeholder,
+  value,
+  onChange,
+  onBlur,
+  error,
+  maxLength,
+}) => {
+  return (
+    <div className="mb-7">
+      <label className="block subhead-1-medium text-white mb-[16px]">{label}</label>
+      <input
+        type="text"
+        id={id}
+        name={id}
+        className="w-full h-[66px] px-6 py-5 rounded-[var(--radius-8)] bg-grey-700 text-grey-300  
+                   focus:outline-none focus:ring-2 focus:ring-green-300 border-transparent"
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        maxLength={maxLength}
+      />
+
+      {error && <p className="text-status-error text-sm mt-[6px]">{error}</p>}
+    </div>
+  );
+};
+
+export default FormField;

--- a/src/components/admin/SeminarManage/SeminarForm.tsx
+++ b/src/components/admin/SeminarManage/SeminarForm.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import FormField from '../SeminarManage/FormField';
+import AdminPresentationUpload from '../upload/AdminPresentationUpload';
+
+interface FormErrors {
+  date?: string;
+}
+
+const SeminarForm = () => {
+  const [formData, setFormData] = useState({
+    title: '',
+    date: '',
+    location: '',
+    topic: '',
+  });
+  const [files, setFiles] = useState<File[]>([]);
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  // Input 이벤트 핸들러
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    console.log(e.target);
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // 유효성 검사
+  const validate = (): FormErrors => {
+    const newErros: FormErrors = {};
+    const dateRegex = /^\d{4}\.\d{1,2}\.\d{1,2}\.\d{1,2}:\d{2}$/;
+
+    if (formData.date && !dateRegex.test(formData.date)) {
+      newErros.date = '올바른 형식(YYYY.MM.DD.HH:mm)으로 입력해주세요';
+    }
+
+    return newErros;
+  };
+
+  // Blur 이벤트 핸들러
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const validationErrors = validate();
+    if (e.target.name === 'date') {
+      setErrors((prev) => ({ ...prev, date: validationErrors.date }));
+    }
+  };
+
+  // 파일 업로드 핸들러
+  const handleFileUpload = (newFiles: File[]) => {
+    setFiles((prevFiles) => [...prevFiles, ...newFiles]);
+  };
+
+  // 파일 제거 핸들러
+  const handleFileRemove = (indexToRemove: number) => {
+    setFiles((prevFiles) => prevFiles.filter((_, index) => index !== indexToRemove));
+  };
+
+  return (
+    <div className="p-[24px]">
+      <h2 className="heading-2-bold text-white mb-[24px]">세미나 상세정보</h2>
+
+      <form>
+        <FormField
+          label="제목"
+          id="title"
+          placeholder="제목을 입력해주세요."
+          value={formData.title}
+          onChange={handleInputChange}
+        />
+        <FormField
+          label="일정"
+          id="date"
+          placeholder="일정을 입력해주세요. (ex: 2025.10.8.18:00)"
+          value={formData.date}
+          onChange={handleInputChange}
+          onBlur={handleBlur}
+          error={errors.date}
+        />
+        <FormField
+          label="장소"
+          id="location"
+          placeholder="장소를 입력해주세요."
+          value={formData.location}
+          onChange={handleInputChange}
+        />
+        <FormField
+          label="주제"
+          id="topic"
+          placeholder="주제를 입력해주세요. (20자 이내)"
+          value={formData.topic}
+          onChange={handleInputChange}
+          maxLength={20}
+        />
+
+        <p className='subhead-1-medium text-white mb-[16px]'>발표자료</p>
+        <AdminPresentationUpload onUpload={handleFileUpload} onRemove={handleFileRemove} />
+      </form>
+    </div>
+  );
+};
+
+export default SeminarForm;


### PR DESCRIPTION
## 🧾 관련 이슈

close : #30 


## 🔍 구현한 내용

어드민의 세미나 상세 정보 폼 컴포넌트를 구현했습니다.


## 📸 스크린샷(선택사항)


<img width="1404" height="941" alt="image" src="https://github.com/user-attachments/assets/a498c329-506e-4993-bc2b-49dc1fcf855b" />

<img width="1404" height="941" alt="image" src="https://github.com/user-attachments/assets/be8ca77b-d2d4-4424-ab8c-9c2107c28739" />




## 🙌 리뷰어에게

- 입력 칸에 focus시 ring이 나타나게 구현했습니다.
- 일정의 경우 형식에 맞추지 않을 시 나중에 문제가 될 것 같아, 형식에 맞추지 않을 시 에러 메세지가 표시되게 했습니다.
- 입력 칸의 최소, 최대 크기는 추후 상세정보  페이지에서 전체적으로 추가할 예정입니다.