### PR TITLE
[UI] 세미나 홈 ui 구현

### DIFF
--- a/src/components/Chip/ChipSeminar.tsx
+++ b/src/components/Chip/ChipSeminar.tsx
@@ -1,7 +1,13 @@
-export const ChipSeminar = () => {
+type ChipSeminarProps = {
+  seminarNumber: number;
+};
+
+const ChipSeminar = ({ seminarNumber }: ChipSeminarProps) => {
   return (
     <button className="w-[84px] h-[25px] bg-grey-900 rounded-4">
-      <p className="caption-semibold text-gradient">10회차 세미나</p>
+      <p className="caption-semibold text-gradient">{seminarNumber}회차 세미나</p>
     </button>
   );
 };
+
+export default ChipSeminar;

--- a/src/components/Semina/SeminaListCard.tsx
+++ b/src/components/Semina/SeminaListCard.tsx
@@ -1,26 +1,33 @@
 import { ChipSeminar } from '../Chip/ChipSeminar';
 
-const SeminaListCard = () => {
+interface SeminarItem {
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  image: string;
+}
+// 임의로 작성 -> 추후 API 연동 시 변경 필요
+
+const SeminaListCard = ({ title, date, time, location, image }: SeminarItem) => {
   return (
     <div className="w-[335px] h-[263px] pt-20 pb-24 gap-20 flex flex-col">
       <div className="h-[93px] flex flex-col gap-12">
         <ChipSeminar />
-        <div className="heading-3-semibold text-white">
-          세미나 제목 영역입니다 <br /> 세미나 제목 영역입니다아아
-        </div>
+        <div className="heading-3-semibold text-white">{title}</div>
       </div>
       <div className="h-[106px] flex flex-row gap-16">
-        <img src="/" alt="seminar Img" className="w-[150px] h-[106px] rounded-8" />
+        <img src={image} alt="seminar Img" className="w-[150px] h-[106px] rounded-8" />
         <div className="h-[68px] flex flex-col gap-8 justify-between body-2-medium">
           <div className="flex flex-row gap-20 ailgn-start">
             <div className="text-grey-300 whitespace-nowrap">일정</div>
             <div className="text-grey-400">
-              2025. 10. 04.(토) <br /> 오후 7:00
+              {date} <br /> {time}
             </div>
           </div>
           <div className="flex flex-row gap-20 ailgn-start">
             <div className="text-grey-300">장소</div>
-            <div className="text-grey-400">가나다라마바사</div>
+            <div className="text-grey-400">{location}</div>
           </div>
         </div>
       </div>

--- a/src/components/Semina/SeminaListCard.tsx
+++ b/src/components/Semina/SeminaListCard.tsx
@@ -12,7 +12,7 @@ interface SeminarItem {
 
 const SeminaListCard = ({ id, title, date, time, location, image }: SeminarItem) => {
   return (
-    <div className="w-[335px] h-[263px] pt-20 pb-24 gap-20 flex flex-col">
+    <div className="w-[335px] h-[263px] pt-20 pb-24 gap-20 flex flex-col cursor-pointer">
       <div className="h-[93px] flex flex-col gap-12">
         <ChipSeminar seminarNumber={id} />
         <div className="heading-3-semibold text-white whitespace-pre-line">{title}</div>

--- a/src/components/Semina/SeminaListCard.tsx
+++ b/src/components/Semina/SeminaListCard.tsx
@@ -1,6 +1,7 @@
-import { ChipSeminar } from '../Chip/ChipSeminar';
+import ChipSeminar from '../Chip/ChipSeminar';
 
 interface SeminarItem {
+  id: number;
   title: string;
   date: string;
   time: string;
@@ -9,11 +10,11 @@ interface SeminarItem {
 }
 // 임의로 작성 -> 추후 API 연동 시 변경 필요
 
-const SeminaListCard = ({ title, date, time, location, image }: SeminarItem) => {
+const SeminaListCard = ({ id, title, date, time, location, image }: SeminarItem) => {
   return (
     <div className="w-[335px] h-[263px] pt-20 pb-24 gap-20 flex flex-col">
       <div className="h-[93px] flex flex-col gap-12">
-        <ChipSeminar />
+        <ChipSeminar seminarNumber={id} />
         <div className="heading-3-semibold text-white whitespace-pre-line">{title}</div>
       </div>
       <div className="h-[106px] flex flex-row gap-16">

--- a/src/components/Semina/SeminaListCard.tsx
+++ b/src/components/Semina/SeminaListCard.tsx
@@ -14,7 +14,7 @@ const SeminaListCard = ({ title, date, time, location, image }: SeminarItem) => 
     <div className="w-[335px] h-[263px] pt-20 pb-24 gap-20 flex flex-col">
       <div className="h-[93px] flex flex-col gap-12">
         <ChipSeminar />
-        <div className="heading-3-semibold text-white">{title}</div>
+        <div className="heading-3-semibold text-white whitespace-pre-line">{title}</div>
       </div>
       <div className="h-[106px] flex flex-row gap-16">
         <img src={image} alt="seminar Img" className="w-[150px] h-[106px] rounded-8" />

--- a/src/components/Seminar/SeminarListCard.tsx
+++ b/src/components/Seminar/SeminarListCard.tsx
@@ -20,13 +20,13 @@ const SeminarListCard = ({ id, title, date, time, location, image }: SeminarItem
       <div className="h-[106px] flex flex-row gap-16">
         <img src={image} alt="seminar Img" className="w-[150px] h-[106px] rounded-8" />
         <div className="h-[68px] flex flex-col gap-8 justify-between body-2-medium">
-          <div className="flex flex-row gap-20 ailgn-start">
+          <div className="flex flex-row gap-20 align-start">
             <div className="text-grey-300 whitespace-nowrap">일정</div>
             <div className="text-grey-400">
               {date} <br /> {time}
             </div>
           </div>
-          <div className="flex flex-row gap-20 ailgn-start">
+          <div className="flex flex-row gap-20 align-start">
             <div className="text-grey-300">장소</div>
             <div className="text-grey-400">{location}</div>
           </div>

--- a/src/components/Seminar/SeminarListCard.tsx
+++ b/src/components/Seminar/SeminarListCard.tsx
@@ -10,7 +10,7 @@ interface SeminarItem {
 }
 // 임의로 작성 -> 추후 API 연동 시 변경 필요
 
-const SeminaListCard = ({ id, title, date, time, location, image }: SeminarItem) => {
+const SeminarListCard = ({ id, title, date, time, location, image }: SeminarItem) => {
   return (
     <div className="w-[335px] h-[263px] pt-20 pb-24 gap-20 flex flex-col cursor-pointer">
       <div className="h-[93px] flex flex-col gap-12">
@@ -36,4 +36,4 @@ const SeminaListCard = ({ id, title, date, time, location, image }: SeminarItem)
   );
 };
 
-export default SeminaListCard;
+export default SeminarListCard;

--- a/src/pages/user/home/Home.tsx
+++ b/src/pages/user/home/Home.tsx
@@ -1,7 +1,22 @@
+import Header from '../../../components/common/Header';
+import SeminaListCard from '../../../components/Semina/SeminaListCard';
+
 function Home() {
   return (
-    <div>
-      <h1>홈 페이지</h1>
+    <div className="flex flex-col justify-center gap-16 px-20">
+      <Header />
+      <div className="heading-1-bold text-white">세미나</div>
+      <div className="flex flex-col gap-28 items-center ">
+        <div className="border-t border-grey-700">
+          <SeminaListCard />
+        </div>
+        <div className="border-t border-grey-700">
+          <SeminaListCard />
+        </div>
+        <div className="border-t border-grey-700">
+          <SeminaListCard />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/user/home/Home.tsx
+++ b/src/pages/user/home/Home.tsx
@@ -1,22 +1,7 @@
-import Header from '../../../components/common/Header';
-import SeminaListCard from '../../../components/Semina/SeminaListCard';
-
 function Home() {
   return (
-    <div className="flex flex-col justify-center gap-16 px-20">
-      <Header />
-      <div className="heading-1-bold text-white">세미나</div>
-      <div className="flex flex-col gap-28 items-center ">
-        <div className="border-t border-grey-700">
-          <SeminaListCard />
-        </div>
-        <div className="border-t border-grey-700">
-          <SeminaListCard />
-        </div>
-        <div className="border-t border-grey-700">
-          <SeminaListCard />
-        </div>
-      </div>
+    <div>
+      <h1>홈 페이지</h1>
     </div>
   );
 }

--- a/src/pages/user/seminar/Home.tsx
+++ b/src/pages/user/seminar/Home.tsx
@@ -1,6 +1,33 @@
 import Header from '../../../components/common/Header';
 import SeminaListCard from '../../../components/Semina/SeminaListCard';
 
+const seminarListData = [
+  {
+    id: 10,
+    title: '세미나 제목 영역입니다 \n 세미나 제목 영역입니다아아',
+    date: '2025. 10. 04.(토)',
+    time: '오후 7:00',
+    location: '가나다라마바사',
+    image: '/images/seminar1.png',
+  },
+  {
+    id: 9,
+    title: '두 번째 세미나 제목\n 두 번째 세미나아아아ㅏㅇ',
+    date: '2025. 10. 3.(금)',
+    time: '오후 5:00',
+    location: '서울특별시 강남구',
+    image: '/images/seminar2.png',
+  },
+  {
+    id: 8,
+    title: '세 번째 세미나 제목 \n 세번째 입니다아우와',
+    date: '2025. 10. 2.(목)',
+    time: '오후 2:00',
+    location: '홍익대학교',
+    image: '/images/seminar3.png',
+  },
+];
+
 function SeminarHome() {
   return (
     <div>
@@ -8,15 +35,18 @@ function SeminarHome() {
         <Header />
         <div className="heading-1-bold text-white">세미나</div>
         <div className="flex flex-col gap-28 items-center ">
-          <div className="border-t border-grey-700">
-            <SeminaListCard />
-          </div>
-          <div className="border-t border-grey-700">
-            <SeminaListCard />
-          </div>
-          <div className="border-t border-grey-700">
-            <SeminaListCard />
-          </div>
+          {seminarListData.map((seminar) => (
+            <div className="border-t border-grey-700">
+              <SeminaListCard
+                key={seminar.id}
+                title={seminar.title}
+                date={seminar.date}
+                time={seminar.time}
+                location={seminar.location}
+                image={seminar.image}
+              />
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/user/seminar/Home.tsx
+++ b/src/pages/user/seminar/Home.tsx
@@ -1,9 +1,24 @@
+import Header from '../../../components/common/Header';
 import SeminaListCard from '../../../components/Semina/SeminaListCard';
 
 function SeminarHome() {
   return (
     <div>
-      <SeminaListCard />
+      <div className="flex flex-col justify-center gap-16 px-20">
+        <Header />
+        <div className="heading-1-bold text-white">세미나</div>
+        <div className="flex flex-col gap-28 items-center ">
+          <div className="border-t border-grey-700">
+            <SeminaListCard />
+          </div>
+          <div className="border-t border-grey-700">
+            <SeminaListCard />
+          </div>
+          <div className="border-t border-grey-700">
+            <SeminaListCard />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/user/seminar/Home.tsx
+++ b/src/pages/user/seminar/Home.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import Header from '../../../components/common/Header';
-import SeminaListCard from '../../../components/Semina/SeminaListCard';
+import SeminarListCard from '../../../components/Seminar/SeminarListCard';
 
 const seminarListData = [
   {
@@ -44,7 +44,7 @@ function SeminarHome() {
         <div className="flex flex-col gap-28 items-center ">
           {seminarListData.map((seminar) => (
             <div className="border-t border-grey-700" onClick={() => handleCardClick(seminar.id)}>
-              <SeminaListCard
+              <SeminarListCard
                 key={seminar.id}
                 id={seminar.id}
                 title={seminar.title}

--- a/src/pages/user/seminar/Home.tsx
+++ b/src/pages/user/seminar/Home.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import Header from '../../../components/common/Header';
 import SeminaListCard from '../../../components/Semina/SeminaListCard';
 
@@ -26,9 +27,15 @@ const seminarListData = [
     location: '홍익대학교',
     image: '/images/seminar3.png',
   },
-];
+]; // 임시 데이터
 
 function SeminarHome() {
+  const navigate = useNavigate();
+
+  const handleCardClick = (id: number) => {
+    navigate(`/seminar/${id}`);
+  };
+
   return (
     <div>
       <div className="flex flex-col justify-center gap-16 px-20">
@@ -36,7 +43,7 @@ function SeminarHome() {
         <div className="heading-1-bold text-white">세미나</div>
         <div className="flex flex-col gap-28 items-center ">
           {seminarListData.map((seminar) => (
-            <div className="border-t border-grey-700">
+            <div className="border-t border-grey-700" onClick={() => handleCardClick(seminar.id)}>
               <SeminaListCard
                 key={seminar.id}
                 id={seminar.id}

--- a/src/pages/user/seminar/Home.tsx
+++ b/src/pages/user/seminar/Home.tsx
@@ -39,6 +39,7 @@ function SeminarHome() {
             <div className="border-t border-grey-700">
               <SeminaListCard
                 key={seminar.id}
+                id={seminar.id}
                 title={seminar.title}
                 date={seminar.date}
                 time={seminar.time}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #47 


## 🔍 구현한 내용

세미나 칩 컴포넌트를 props 받도록 수정했습니다
각각 세미나 카드들은 선택 시 상세 사항 페이지로 넘어가도록 구현했습니다


## 📸 스크린샷(선택사항)
<img width="501" height="795" alt="image" src="https://github.com/user-attachments/assets/b93de796-a6e8-40cb-92c8-1dfb0f2e88d3" />




## 🙌 리뷰어에게
