### PR TITLE
[UI] 어드민 세미나 라이브 링크 컴포넌트 구현

### DIFF
--- a/src/components/admin/SeminarManage/LiveLinkInput.tsx
+++ b/src/components/admin/SeminarManage/LiveLinkInput.tsx
@@ -14,7 +14,7 @@ const LiveLinkInput: React.FC<LiveLinkInputProps> = ({ link, onLinkChange }) => 
       <h2 className="heading-2-bold text-white mb-6">세미나 Live 링크</h2>
       <input
         type="url"
-        className="w-full h-[66px] px-6 py-5 rounded-[var(--radius-8)] bg-grey-700 text-grey-300  
+        className="w-full h-[66px] px-6 py-5 rounded-8 bg-grey-700 text-grey-300  
                    focus:outline-none focus:ring-2 focus:ring-green-300 border-transparent"
         placeholder="링크 URL을 입력해주세요."
         value={link}

--- a/src/components/admin/SeminarManage/LiveLinkInput.tsx
+++ b/src/components/admin/SeminarManage/LiveLinkInput.tsx
@@ -10,7 +10,7 @@ const LiveLinkInput: React.FC<LiveLinkInputProps> = ({ link, onLinkChange }) => 
   };
 
   return (
-    <div>
+    <div className="bg-grey-900 p-6 rounded-10">
       <h2 className="heading-2-bold text-white mb-6">세미나 Live 링크</h2>
       <input
         type="url"

--- a/src/components/admin/SeminarManage/LiveLinkInput.tsx
+++ b/src/components/admin/SeminarManage/LiveLinkInput.tsx
@@ -1,0 +1,27 @@
+interface LiveLinkInputProps {
+  link: string;
+  onLinkChange: (newLink: string) => void;
+}
+
+const LiveLinkInput: React.FC<LiveLinkInputProps> = ({ link, onLinkChange }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onLinkChange(e.target.value);
+    console.log(e.target.value);
+  };
+
+  return (
+    <div>
+      <h2 className="heading-2-bold text-white mb-6">세미나 Live 링크</h2>
+      <input
+        type="url"
+        className="w-full h-[66px] px-6 py-5 rounded-[var(--radius-8)] bg-grey-700 text-grey-300  
+                   focus:outline-none focus:ring-2 focus:ring-green-300 border-transparent"
+        placeholder="링크 URL을 입력해주세요."
+        value={link}
+        onChange={handleChange}
+      />
+    </div>
+  );
+};
+
+export default LiveLinkInput;


### PR DESCRIPTION
## 🧾 관련 이슈
close : #61


## 🔍 구현한 내용

어드민의 세미나 라이브 링크 컴포넌트를 구현했습니다.


## 📸 스크린샷(선택사항)


<img width="1401" height="931" alt="image" src="https://github.com/user-attachments/assets/972512a2-aab2-49bb-af5b-9af45bb29d4f" />


## 🙌 리뷰어에게

- 입력 칸에 focus시 ring이 나타나게 구현했습니다.
- 입력 칸의 최소, 최대 크기는 추후 상세정보 페이지에서 전체적으로 추가할 예정입니다.
