### PR TITLE
[SETTING] 공통 응답 타입 세팅

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,7 @@
+export type CommonResponse<T = null> = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result?: T;
+  error?: Record<string, any> | null;
+};


### PR DESCRIPTION
## 🧾 관련 이슈
close : #106 


## 🔍 구현한 내용
- Swagger 문서 상의 공통 응답 타입을 세팅했습니다.



## 📸 스크린샷(선택사항)
- 이 사진은 노션의 SpringBoot >컨벤션 > 공통 api 응답 형식 에 있습니다.
<img width="1037" height="558" alt="스크린샷 2025-10-02 125658" src="https://github.com/user-attachments/assets/993b682c-fbfa-4bb7-80c7-a9803a805f13" />

- Swagger상의 error 필드 예시가 이 경우만 있는 것 같아 우선 `error?: Record<string, any> | null;` 로 코딩해두었습니다.
<img width="811" height="496" alt="image" src="https://github.com/user-attachments/assets/bed3f0d2-c8ad-40b6-8f94-caf514ac351c" />



## 🙌 리뷰어에게
앞으로 API 응답 타입 세팅하실 때 이 CommonResponse 이용하시면 됩니다!