### PR TITLE
[UI] 세미나 활성화 기간 설정 컴포넌트 디자인 수정

### DIFF
--- a/src/components/admin/seminar-manage/ActivationDate/ActiveDateForm.tsx
+++ b/src/components/admin/seminar-manage/ActivationDate/ActiveDateForm.tsx
@@ -9,7 +9,8 @@ interface ActiveDateProps {
     dateType: 'seminarStartDate' | 'seminarEndDate' | 'applicationStartDate' | 'applicationEndDate',
     newDate: Date
   ) => void;
-  error?: string;
+  seminarDateError?: string;
+  applicationDateError?: string;
 }
 
 const ActiveDateForm = ({
@@ -18,12 +19,13 @@ const ActiveDateForm = ({
   applicationStartDate,
   applicationEndDate,
   onChange,
-  error,
+  seminarDateError,
+  applicationDateError,
 }: ActiveDateProps) => {
   return (
     <div className="space-y-6">
       {/* 현재 세미나 활성화 기간 */}
-      <div className="bg-grey-900 p-6 rounded-10 min-h-[250px]">
+      <div className="bg-grey-900 p-6 rounded-10 min-h-[240px]">
         <h2 className="heading-2-bold text-white mb-6">현재 세미나 활성화 기간</h2>
         <div className="flex flex-col gap-y-9">
           <DateTimeSelector
@@ -38,10 +40,13 @@ const ActiveDateForm = ({
             />
           </div>
         </div>
+        {seminarDateError && (
+          <p className="text-status-error text-sm text-right mt-3">{seminarDateError}</p>
+        )}
       </div>
 
       {/* 세미나 신청 활성화 기간 */}
-      <div className="bg-grey-900 p-6 rounded-10 min-h-[250px]">
+      <div className="bg-grey-900 p-6 rounded-10 min-h-[240px]">
         <h2 className="heading-2-bold text-white mb-6">세미나 신청 활성화 기간</h2>
         <div className="flex flex-col gap-y-9">
           <DateTimeSelector
@@ -56,7 +61,9 @@ const ActiveDateForm = ({
             />
           </div>
         </div>
-        {error && <p className="text-status-error text-sm mt-3">{error}</p>}
+        {applicationDateError && (
+          <p className="text-status-error text-sm text-right mt-3">{applicationDateError}</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/admin/seminar-manage/ActivationDate/ActiveDateForm.tsx
+++ b/src/components/admin/seminar-manage/ActivationDate/ActiveDateForm.tsx
@@ -1,31 +1,61 @@
 import DateTimeSelector from './DateTimeSelector';
 
 interface ActiveDateProps {
-  seminarDate: Date;
-  applicationDate: Date;
-  onChange: (dateType: 'seminarDate' | 'applicationDate', newDate: Date) => void;
+  seminarStartDate: Date;
+  seminarEndDate: Date;
+  applicationStartDate: Date;
+  applicationEndDate: Date;
+  onChange: (
+    dateType: 'seminarStartDate' | 'seminarEndDate' | 'applicationStartDate' | 'applicationEndDate',
+    newDate: Date
+  ) => void;
   error?: string;
 }
 
-const ActiveDateForm = ({ seminarDate, applicationDate, onChange, error }: ActiveDateProps) => {
+const ActiveDateForm = ({
+  seminarStartDate,
+  seminarEndDate,
+  applicationStartDate,
+  applicationEndDate,
+  onChange,
+  error,
+}: ActiveDateProps) => {
   return (
     <div className="space-y-6">
       {/* 현재 세미나 활성화 기간 */}
-      <div className="bg-grey-900 p-6 rounded-10 h-[170px]">
+      <div className="bg-grey-900 p-6 rounded-10 min-h-[250px]">
         <h2 className="heading-2-bold text-white mb-6">현재 세미나 활성화 기간</h2>
-        <DateTimeSelector
-          date={seminarDate}
-          onDateChange={(newDate) => onChange('seminarDate', newDate)}
-        />
+        <div className="flex flex-col gap-y-9">
+          <DateTimeSelector
+            date={seminarStartDate}
+            onDateChange={(newDate) => onChange('seminarStartDate', newDate)}
+          />
+          <div className="flex items-center gap-x-3 ml-auto">
+            <span className="subhead-1-semibold text-white">~</span>
+            <DateTimeSelector
+              date={seminarEndDate}
+              onDateChange={(newDate) => onChange('seminarEndDate', newDate)}
+            />
+          </div>
+        </div>
       </div>
 
       {/* 세미나 신청 활성화 기간 */}
-      <div className="bg-grey-900 p-6 rounded-10 h-[170px]">
+      <div className="bg-grey-900 p-6 rounded-10 min-h-[250px]">
         <h2 className="heading-2-bold text-white mb-6">세미나 신청 활성화 기간</h2>
-        <DateTimeSelector
-          date={applicationDate}
-          onDateChange={(newDate) => onChange('applicationDate', newDate)}
-        />
+        <div className="flex flex-col gap-y-9">
+          <DateTimeSelector
+            date={applicationStartDate}
+            onDateChange={(newDate) => onChange('applicationStartDate', newDate)}
+          />
+          <div className="flex items-center gap-x-3 ml-auto">
+            <span className="subhead-1-semibold text-white">~</span>
+            <DateTimeSelector
+              date={applicationEndDate}
+              onDateChange={(newDate) => onChange('applicationEndDate', newDate)}
+            />
+          </div>
+        </div>
         {error && <p className="text-status-error text-sm mt-3">{error}</p>}
       </div>
     </div>

--- a/src/components/admin/seminar-manage/ActivationDate/CustomSelect.tsx
+++ b/src/components/admin/seminar-manage/ActivationDate/CustomSelect.tsx
@@ -73,7 +73,7 @@ const CustomSelect = ({ options, selectedValue, onSelect }: CustomSelectProps) =
         <ul
           ref={optionsListRef}
           className={`
-            absolute z-10 w-full max-h-[250px] overflow-y-auto bg-grey-700 border border-grey-600 rounded-8 scrollbar-hide
+            absolute z-10 w-full max-h-[200px] overflow-y-auto bg-grey-700 border border-grey-600 rounded-8 scrollbar-hide
             ${position === 'bottom' ? 'top-full mt-3' : 'bottom-full mb-3'}
           `}
         >

--- a/src/components/admin/seminar-manage/ActivationDate/DateTimeSelector.tsx
+++ b/src/components/admin/seminar-manage/ActivationDate/DateTimeSelector.tsx
@@ -19,22 +19,31 @@ const DateTimeSelector = ({ date, onDateChange }: DateTimeSelectorProps) => {
     onDateChange(newDate);
   };
 
+  const getDayInMonth = (year: number, month: number) => {
+    return new Date(year, month, 0).getDate();
+  };
+
   // CustomSelect에 맞는 {value, label} 형태의 배열로 변환
   const yearOptions = Array.from({ length: 3 }, (_, i) => new Date().getFullYear() + i).map(
     (y) => ({ value: y, label: String(y) })
   );
+
   const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1).map((m) => ({
     value: m,
     label: String(m).padStart(2, '0'),
   }));
-  const dayOptions = Array.from({ length: 31 }, (_, i) => i + 1).map((d) => ({
+
+  const daysInSelctedMonth = getDayInMonth(date.getFullYear(), date.getMonth() + 1);
+  const dayOptions = Array.from({ length: daysInSelctedMonth }, (_, i) => i + 1).map((d) => ({
     value: d,
     label: String(d).padStart(2, '0'),
   }));
+
   const hourOptions = Array.from({ length: 24 }, (_, i) => i).map((h) => ({
     value: h,
     label: String(h).padStart(2, '0'),
   }));
+
   const minuteOptions = [0, 15, 30, 45].map((m) => ({
     value: m,
     label: String(m).padStart(2, '0'),

--- a/src/components/admin/seminar-manage/MainContent.tsx
+++ b/src/components/admin/seminar-manage/MainContent.tsx
@@ -11,7 +11,7 @@ interface MainContentProps {
   showReviewList: boolean;
   currentState: SeminarDetails;
   validationErrors: FormErrors;
-  activationError: string;
+  activationError: { seminar: string; application: string };
   updateSeminarData: (data: Partial<SeminarDetails>) => void;
   handleBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
   handleRegisterReviewToHome?: (reviewId: number) => void;
@@ -69,7 +69,8 @@ const MainContent = ({
       applicationStartDate={currentState.applicationStartDate}
       applicationEndDate={currentState.applicationEndDate}
       onChange={(dateType, newDate) => updateSeminarData({ [dateType]: newDate })}
-      error={activationError}
+      seminarDateError={activationError.seminar}
+      applicationDateError={activationError.application}
     />
   </main>
 );

--- a/src/components/admin/seminar-manage/MainContent.tsx
+++ b/src/components/admin/seminar-manage/MainContent.tsx
@@ -64,8 +64,10 @@ const MainContent = ({
     />
 
     <ActiveDateForm
-      seminarDate={currentState.seminarDate}
-      applicationDate={currentState.applicationDate}
+      seminarStartDate={currentState.seminarStartDate}
+      seminarEndDate={currentState.seminarEndDate}
+      applicationStartDate={currentState.applicationStartDate}
+      applicationEndDate={currentState.applicationEndDate}
       onChange={(dateType, newDate) => updateSeminarData({ [dateType]: newDate })}
       error={activationError}
     />

--- a/src/hooks/SeminarManage/useSeminarState.ts
+++ b/src/hooks/SeminarManage/useSeminarState.ts
@@ -63,8 +63,10 @@ const initialData: SeminarDetails = {
       createdAt: '2025. 10. 4.(토) 오후 7:00',
     },
   ],
-  seminarDate: new Date(),
-  applicationDate: new Date(),
+  seminarStartDate: new Date(),
+  seminarEndDate: new Date(),
+  applicationStartDate: new Date(),
+  applicationEndDate: new Date(),
 };
 
 const blankSpeakerState: Speaker = {
@@ -86,8 +88,10 @@ const blankData: SeminarDetails = {
   speakers: [blankSpeakerState, blankSpeakerState],
   liveLink: '',
   reviews: [],
-  seminarDate: new Date(),
-  applicationDate: new Date(),
+  seminarStartDate: new Date(),
+  seminarEndDate: new Date(),
+  applicationStartDate: new Date(),
+  applicationEndDate: new Date(),
 };
 
 export const useSeminarState = (id: string | undefined) => {
@@ -154,7 +158,11 @@ export const useSeminarState = (id: string | undefined) => {
 
   // 활성화 날짜 검증
   useEffect(() => {
-    if (state.currentState && state.currentState.seminarDate < state.currentState.applicationDate) {
+    if (
+      state.currentState &&
+      (state.currentState.seminarStartDate > state.currentState.applicationStartDate ||
+        state.currentState.seminarEndDate < state.currentState.applicationEndDate)
+    ) {
       setState((prev) => ({
         ...prev,
         activationError: '※ 신청 활성화 시간은 세미나 활성화 시간보다 나중으로 설정할 수 없습니다.',
@@ -200,8 +208,18 @@ export const useSeminarState = (id: string | undefined) => {
   const validateRequiredFields = (): boolean => {
     if (!state.currentState) return false;
 
-    const { mainImageUrl, title, date, location, topic, speakers, seminarDate, applicationDate } =
-      state.currentState;
+    const {
+      mainImageUrl,
+      title,
+      date,
+      location,
+      topic,
+      speakers,
+      seminarStartDate,
+      seminarEndDate,
+      applicationStartDate,
+      applicationEndDate,
+    } = state.currentState;
 
     // 기본 필드 검증
     if (!title.trim() || !date.trim() || !location.trim() || !topic.trim()) {
@@ -232,7 +250,7 @@ export const useSeminarState = (id: string | undefined) => {
       return false;
     }
 
-    if (!seminarDate || !applicationDate) {
+    if (!seminarStartDate || !seminarEndDate || !applicationStartDate || !applicationEndDate) {
       return false;
     }
 

--- a/src/types/SeminarManage/seminar.ts
+++ b/src/types/SeminarManage/seminar.ts
@@ -54,5 +54,5 @@ export interface SeminarState {
   error: string | null;
   isDirty: boolean;
   validationErrors: FormErrors;
-  activationError: string;
+  activationError: { seminar: string; application: string };
 }

--- a/src/types/SeminarManage/seminar.ts
+++ b/src/types/SeminarManage/seminar.ts
@@ -37,8 +37,10 @@ export interface SeminarDetails {
   speakers: Speaker[];
   liveLink: string;
   reviews: Review[];
-  seminarDate: Date;
-  applicationDate: Date;
+  seminarStartDate: Date;
+  seminarEndDate: Date;
+  applicationStartDate: Date;
+  applicationEndDate: Date;
 }
 
 export interface FormErrors {


### PR DESCRIPTION
## 🧾 관련 이슈
close : #96 


## 🔍 구현한 내용

어드민의 현재 및 신청 세미나 활성화 기간 수정하는 컴포넌트를 디자인이 수정됨에 따라 수정했습니다.


## 📸 스크린샷(선택사항)

<img width="1057" height="539" alt="image" src="https://github.com/user-attachments/assets/fa203b3f-4b46-483c-a78b-697d43cba1e2" />


<img width="1057" height="274" alt="image" src="https://github.com/user-attachments/assets/9190ebaa-e683-4a05-b463-70a96736321f" />

<img width="1057" height="274" alt="image" src="https://github.com/user-attachments/assets/dfaa7d23-698d-45bf-b5f2-52b92e5e1d6f" />

<img width="1057" height="274" alt="image" src="https://github.com/user-attachments/assets/e00a883b-4aac-405c-9bb0-6ede36e4847f" />



## 🙌 리뷰어에게

- 시작과 끝을 각각 입력할 수 있게 변경되면서 기간 선택에 대한 오류 메세지를 추가 했습니다.
- 오류 메세지 순서는 `'시작 > 끝'` or` '시작 = 끝'` -> `'세미나 기간에 신청 기간 포함 X'` 입니다.

- 월 선택시 각 월의 마지막 날에 해당하는 날까지만 드롭다운에 나오게 했습니다.
