### PR TITLE
[FEAT] 어드민 사이드바 하이라이트 기능 추가

### DIFF
--- a/src/layouts/admin/Sidebar.tsx
+++ b/src/layouts/admin/Sidebar.tsx
@@ -8,28 +8,28 @@ const menuData = [
   {
     title: '홈 화면 관리',
     children: [
-      { name: '홍보 사진 관리', to: '/admin/home/promo' },
-      { name: '링크 관리', to: '/admin/home/links' },
-      { name: '후기 카드 갤러리', to: '/admin/home/reviews' },
+      { name: '홍보 사진 관리', to: '/admin/home/promo', end: true },
+      { name: '링크 관리', to: '/admin/home/links', end: true },
+      { name: '후기 카드 갤러리', to: '/admin/home/reviews', end: true },
     ],
   },
   {
     title: '세미나 관리',
     children: [
-      { name: '세미나 카드 조회', to: '/admin/seminars' },
-      { name: '세미나 추가하기', to: '/admin/seminars/add' },
-      { name: '세미나 신청자 관리', to: '/admin/seminars/applicants' },
+      { name: '세미나 카드 조회', to: '/admin/seminars', end: true },
+      { name: '세미나 추가하기', to: '/admin/seminars/add', end: true },
+      { name: '세미나 신청자 관리', to: '/admin/seminars/applicants', end: false },
     ],
   },
   {
     title: '세미나 Live 관리',
     children: [
-      { name: '출석 관리', to: '/admin/seminar-live/attendance' },
+      { name: '출석 관리', to: '/admin/seminar-live/attendance', end: true },
     ],
   },
   {
     title: '관리자 권한 관리',
-    children: [{ name: '관리자 아이디 관리', to: '/admin/admin-accounts' }],
+    children: [{ name: '관리자 아이디 관리', to: '/admin/admin-accounts', end: true }],
   },
 ];
 
@@ -81,7 +81,7 @@ export const Sidebar: React.FC = () => {
                     <li key={item.name}>
                       <NavLink
                         to={item.to}
-                        end // 정확히 일치하는 경로에서만 스타일 적용
+                        end={item.end}
                         className={({ isActive }) =>
                           `flex items-center h-[40px] py-3 px-[40px] cursor-pointer subhead-1-medium relative transition-colors ${
                             isActive ? activeLinkStyle : inactiveLinkStyle


### PR DESCRIPTION
## 🧾 관련 이슈
close : #77 


## 🔍 구현한 내용
어드민 사이드바의 메뉴별 end 속성을 분리 적용하여 세미나 신청자 관리 하위 경로에서도 사이드바의 하이라이트가 활성화되도록 개선했습니다



## 📸 스크린샷(선택사항)
<img width="1780" height="918" alt="image" src="https://github.com/user-attachments/assets/a8ae1c93-5f2e-463a-b8a1-e9724a975382" />
<img width="1637" height="955" alt="image" src="https://github.com/user-attachments/assets/437f94f5-74a2-479b-8275-7f8da496e51b" />





## 🙌 리뷰어에게
