### PR TITLE
[UI] 어드민의 모달 컴포넌트 구현

### DIFF
--- a/src/components/admin/common/AdminModal.tsx
+++ b/src/components/admin/common/AdminModal.tsx
@@ -46,10 +46,10 @@ const AdminModal = ({ isOpen, onClose, onConfirm, variant }: ConfirmModalProps) 
         </div>
 
         {/* 버튼 */}
-        <div className="grid grid-cols-2">
+        <div className="grid grid-cols-2 gap-5">
           <button
             onClick={onClose}
-            className="subhead-1-semibold py-3 px-6 text-white rounded-8 hover:bg-grey-600 transition-colors cursor-pointer"
+            className="subhead-1-semibold py-3 px-5 bg-grey-800 text-white rounded-8 hover:bg-grey-600 transition-colors cursor-pointer"
           >
             {variant === 'cancel' ? '돌아가기' : '취소하기'}
           </button>
@@ -58,7 +58,7 @@ const AdminModal = ({ isOpen, onClose, onConfirm, variant }: ConfirmModalProps) 
               onConfirm();
               onClose();
             }}
-            className="subhead-1-semibold py-3 px-6 rounded-8 transition-colors text-status-error cursor-pointer hover:text-white hover:bg-status-error/40"
+            className="subhead-1-semibold py-3 px-5 bg-status-error/15 rounded-8 transition-colors text-status-error cursor-pointer hover:text-white hover:bg-status-error/40"
           >
             {content.confirmText}
           </button>

--- a/src/components/admin/common/AdminModal.tsx
+++ b/src/components/admin/common/AdminModal.tsx
@@ -34,9 +34,8 @@ const AdminModal = ({ isOpen, onClose, onConfirm, variant }: ConfirmModalProps) 
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/70" onClick={onClose} />
 
-      {/* Modal */}
       <div className="relative bg-grey-700 rounded-8 w-full max-w-[400px] min-h-[200px] mx-4 p-[32px] flex flex-col justify-between">
-        {/* Content */}
+        {/* 모달 내용 */}
         <div className="mb-[20px] text-center">
           <p className="heading-3-semibold text-white mb-[15px] whitespace-pre-line">
             {content.message}
@@ -46,11 +45,11 @@ const AdminModal = ({ isOpen, onClose, onConfirm, variant }: ConfirmModalProps) 
           </p>
         </div>
 
-        {/* Buttons */}
+        {/* 버튼 */}
         <div className="grid grid-cols-2">
           <button
             onClick={onClose}
-            className="subhead-1-semibold py-3 px-6 text-white rounded-8 hover:bg-grey-600 transition-colors scursor-pointer"
+            className="subhead-1-semibold py-3 px-6 text-white rounded-8 hover:bg-grey-600 transition-colors cursor-pointer"
           >
             {variant === 'cancel' ? '돌아가기' : '취소하기'}
           </button>

--- a/src/components/admin/common/AdminModal.tsx
+++ b/src/components/admin/common/AdminModal.tsx
@@ -1,0 +1,72 @@
+type ModalVariant = 'deleteSeminar' | 'deleteReview' | 'cancel';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  variant: ModalVariant;
+}
+
+const MODAL_CONTENT = {
+  deleteSeminar: {
+    message: '해당 세미나를 정말 삭제하시겠습니까?',
+    warningMessage: '삭제 시 해당 세미나의 모든 정보는 삭제되며,\n복구할 수 없습니다.',
+    confirmText: '세미나 삭제하기',
+  },
+  deleteReview: {
+    message: '해당 후기를 정말 삭제하시겠습니까?',
+    warningMessage: '삭제 시 해당 후기의 모든 정보는 삭제되며,\n복구할 수 없습니다.',
+    confirmText: '후기 삭제하기',
+  },
+  cancel: {
+    message: '변경사항이 있습니다.\n정말 취소하시겠습니까?',
+    warningMessage: '취소 시 변경된 모든 내용은 저장되지 않습니다.',
+    confirmText: '취소하기',
+  },
+} as const;
+
+const AdminModal = ({ isOpen, onClose, onConfirm, variant }: ConfirmModalProps) => {
+  if (!isOpen) return null;
+
+  const content = MODAL_CONTENT[variant];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative bg-grey-700 rounded-8 w-full max-w-[400px] min-h-[200px] mx-4 p-[32px] flex flex-col justify-between">
+        {/* Content */}
+        <div className="mb-[20px] text-center">
+          <p className="heading-3-semibold text-white mb-[15px] whitespace-pre-line">
+            {content.message}
+          </p>
+          <p className="body-2-medium text-status-error whitespace-pre-line">
+            {content.warningMessage}
+          </p>
+        </div>
+
+        {/* Buttons */}
+        <div className="grid grid-cols-2">
+          <button
+            onClick={onClose}
+            className="subhead-1-semibold py-3 px-6 text-white rounded-8 hover:bg-grey-600 transition-colors scursor-pointer"
+          >
+            {variant === 'cancel' ? '돌아가기' : '취소하기'}
+          </button>
+          <button
+            onClick={() => {
+              onConfirm();
+              onClose();
+            }}
+            className="subhead-1-semibold py-3 px-6 rounded-8 transition-colors text-status-error cursor-pointer hover:text-white hover:bg-status-error/40"
+          >
+            {content.confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminModal;

--- a/src/hooks/SeminarManage/useReviewActions.ts
+++ b/src/hooks/SeminarManage/useReviewActions.ts
@@ -37,16 +37,14 @@ export const useReviewActions = ({
   const handleDeleteReview = (reviewId: number) => {
     if (!currentState) return;
 
-    if (window.confirm(`${reviewId}번 후기를 정말 삭제하시겠습니까?`)) {
-      const updatedReviews = currentState.reviews.filter((review) => review.reviewId !== reviewId);
+    const updatedReviews = currentState.reviews.filter((review) => review.reviewId !== reviewId);
 
-      // 원본 데이터도 함께 업데이트해서 수정하기 버튼이 활성화되지 않도록
-      const newState = { ...currentState, reviews: updatedReviews };
-      updateSeminarData({ reviews: updatedReviews });
-      setInitialState(newState);
+    // 원본 데이터도 함께 업데이트해서 수정하기 버튼이 활성화되지 않도록
+    const newState = { ...currentState, reviews: updatedReviews };
+    updateSeminarData({ reviews: updatedReviews });
+    setInitialState(newState);
 
-      console.log(`${reviewId}번 후기가 삭제되었습니다.`);
-    }
+    console.log(`${reviewId}번 후기가 삭제되었습니다.`);
   };
 
   return {

--- a/src/pages/admin/home-manage/Reviews.tsx
+++ b/src/pages/admin/home-manage/Reviews.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import HomeReviewItem from '../../../components/admin/home/HomeReviewItem';
 import type { Review } from '../../../components/admin/home/HomeReviewItem';
+import AdminModal from '../../../components/admin/common/AdminModal';
 
 const Reviews = () => {
   // rank 추가한 mock 데이터 넣어둠
@@ -41,6 +42,9 @@ const Reviews = () => {
     },
   ]);
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [reviewToRemove, setReviewToRemove] = useState<number | null>();
+
   const updateRanks = (list: Review[]): Review[] => list.map((r, i) => ({ ...r, rank: i + 1 }));
 
   const moveUp = (id: number) => {
@@ -67,8 +71,18 @@ const Reviews = () => {
     });
   };
 
-  const removeReview = (id: number) => {
-    setReviews((prev) => prev.filter((r) => r.reviewId !== id));
+  // 삭제하기 버튼을 클릭하면, 모달을 연다
+  const handleRemoveClick = (id: number) => {
+    setReviewToRemove(id);
+    setIsModalOpen(true);
+  };
+
+  // 모달에서 '후기 삭제하기' 클릭 시
+  const handleConfirmRemove = () => {
+    if (reviewToRemove !== null) {
+      setReviews((prev) => prev.filter((r) => r.reviewId !== reviewToRemove));
+      setReviewToRemove(null);
+    }
   };
 
   return (
@@ -85,11 +99,18 @@ const Reviews = () => {
               review={review}
               onMoveUp={moveUp}
               onMoveDown={moveDown}
-              onDelete={removeReview}
+              onDelete={handleRemoveClick}
             />
           </div>
         ))}
       </div>
+
+      <AdminModal
+        isOpen={isModalOpen}
+        variant="deleteReview"
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleConfirmRemove}
+      />
     </div>
   );
 };

--- a/src/pages/admin/seminar-manage/Add.tsx
+++ b/src/pages/admin/seminar-manage/Add.tsx
@@ -4,9 +4,12 @@ import { useSeminarState } from '../../../hooks/SeminarManage/useSeminarState';
 import Header from '../../../components/admin/seminar-manage/Header';
 import MainContent from '../../../components/admin/seminar-manage/MainContent';
 import Footer from '../../../components/admin/seminar-manage/Footer';
+import { useState } from 'react';
+import AdminModal from '../../../components/admin/common/AdminModal';
 
 const Add = () => {
   const navigate = useNavigate();
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   // id 없이 훅을 호출하여 add 모드
   const {
@@ -23,20 +26,21 @@ const Add = () => {
   const handleSave = () => {
     if (!currentState) return;
 
-    if (window.confirm('세미나를 추가하시겠습니까?')) {
-      console.log('저장할 데이터: ', currentState);
-      alert('추가되었습니다.');
+    console.log('저장하기 클릭: ', currentState);
+    alert('세미나가 추가되었습니다.');
+    navigate('/admin/seminars');
+  };
+
+  const handleCancelClick = () => {
+    if (isDirty) {
+      setIsModalOpen(true);
+    } else {
       navigate('/admin/seminars');
     }
   };
 
-  // 취소 (변경 사항이 있을 때는 사용자에게 확인을 받음)
-  const handleCancel = () => {
-    if (!currentState) return;
-
-    if (isDirty && window.confirm('변경사항이 있습니다. 정말 취소하시겠습니까?')) {
-      navigate(-1);
-    }
+  const handleConfirm = () => {
+    navigate('/admin/seminars');
   };
 
   if (!currentState) {
@@ -61,7 +65,14 @@ const Add = () => {
         isDirty={isDirty}
         hasErrors={hasErrors}
         onSave={handleSave}
-        onCancel={handleCancel}
+        onCancel={handleCancelClick}
+      />
+
+      <AdminModal
+        isOpen={isModalOpen}
+        variant="cancel"
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleConfirm}
       />
     </div>
   );

--- a/src/pages/admin/seminar-manage/Add.tsx
+++ b/src/pages/admin/seminar-manage/Add.tsx
@@ -31,6 +31,7 @@ const Add = () => {
     navigate('/admin/seminars');
   };
 
+  // 취소하기
   const handleCancelClick = () => {
     if (isDirty) {
       setIsModalOpen(true);
@@ -39,6 +40,7 @@ const Add = () => {
     }
   };
 
+  // 모달 내에서 삭제하기
   const handleConfirm = () => {
     navigate('/admin/seminars');
   };


### PR DESCRIPTION
## 🧾 관련 이슈
close : #117 


## 🔍 구현한 내용

어드민 페이지에서 공통적으로 사용되는 모달을 구현했습니다.


## 📸 스크린샷(선택사항)


<img width="405" height="221" alt="image" src="https://github.com/user-attachments/assets/b68616b1-e18e-427c-a205-24cb43f508c4" />

<img width="405" height="221" alt="image" src="https://github.com/user-attachments/assets/711833b1-7c4e-41c5-9786-db180628875d" />

<img width="405" height="221" alt="image" src="https://github.com/user-attachments/assets/bad9cef9-ca9e-48fc-a3cf-0c132f068d67" />



## 🙌 리뷰어에게

- `components/admin/common/AdminModal.tsx`에 공통적으로 사용되는 모달을 정의했습니다.
-  후기 카드 갤러리 페이지에서도 후기 삭제하기를 클릭했을 때도 이 모달을 사용하도록 변경했습니다.
