### PR TITLE
[UI] 세미나 상세 페이지 스크롤 구현

### DIFF
--- a/src/components/Seminar/SeminarDetailCard.tsx
+++ b/src/components/Seminar/SeminarDetailCard.tsx
@@ -1,6 +1,6 @@
 const SeminarDeailCard = ({ id }: { id: number }) => {
   return (
-    <div className="w-[375px] h-[449px] gap-20 p-20 flex flex-col">
+    <div className="w-[375px] h-[449px] gap-20 p-20 flex flex-col transition-all duration-500 ease-out">
       <div className="w-[335px] h-[404px] gap-[31px] flex flex-col">
         <div className="h-[68px] flex flex-col gap-8 justify-between">
           <div className="subhead-2-medium text-grey-100">{id}회차</div>

--- a/src/components/Seminar/SeminarDetailLectureCard.tsx
+++ b/src/components/Seminar/SeminarDetailLectureCard.tsx
@@ -1,54 +1,63 @@
+import { forwardRef } from 'react';
 import speakerEx from '../../assets/speakerEx.jpg';
 
-const SeminarDetailLectureCard = () => {
-  return (
-    <div className="relative w-[335px] h-[1033px] rounded-[12px] overflow-hidden flex flex-col items-center justify-start">
-      <div className="absolute top-0 w-full h-[427px] top-gradient" />
-      <div className="absolute bottom-0 w-full h-[200px] bottom-gradient" />
-      <img src={speakerEx} alt="연사 이미지" className="w-[335px] h-[427px] object-cover " />
-      <div className="flex flex-col w-[295px] gap-[20px] items-center absolute top-[300px] ">
-        <div className="flex flex-col gap-4 justify-center items-center">
-          <div className="flex gap-[8px] items-center body-2-semibold text-white ">
-            연사 <span className="subhead-1-semibold text-gradient">김데브</span>님
+interface SeminarDetailLectureCardProps {
+  className?: string;
+}
+const SeminarDetailLectureCard = forwardRef<HTMLDivElement, SeminarDetailLectureCardProps>(
+  ({ className }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={`relative w-[335px] h-[1033px] rounded-[12px] overflow-hidden flex flex-col items-center justify-start ${className ?? ''}`}
+      >
+        <div className="absolute top-0 w-full h-[427px] top-gradient" />
+        <div className="absolute bottom-0 w-full h-[200px] bottom-gradient" />
+        <img src={speakerEx} alt="연사 이미지" className="w-[335px] h-[427px] object-cover " />
+        <div className="flex flex-col w-[295px] gap-[20px] items-center absolute top-[300px] ">
+          <div className="flex flex-col gap-4 justify-center items-center">
+            <div className="flex gap-[8px] items-center body-2-semibold text-white ">
+              연사 <span className="subhead-1-semibold text-gradient">김데브</span>님
+            </div>
+            <p className="body-1-medium text-white">前 Kakao · Toss Data Scientist</p>
           </div>
-          <p className="body-1-medium text-white">前 Kakao · Toss Data Scientist</p>
+          <ul className="w-[273px] h-[140px] pl-5 body-2-medium text-grey-200 list-disc list-outside">
+            <li>前 Toss Securities Data Scientist (2021)</li>
+            <li>前 Kakao Corp Data Scientist (2020)</li>
+            <li>성균관대학교 통계학 학사 졸업</li>
+            <li>F사 프로젝트 멘토/ 강사 (2020~2023)</li>
+            <li>N사 부스트 캠프 멘토/강사 (2022~2023)</li>
+            <li>S사 부트캠프 데이터 분석 멘토/강사 (2023~2024)</li>
+          </ul>
         </div>
-        <ul className="w-[273px] h-[140px] pl-5 body-2-medium text-grey-200 list-disc list-outside">
-          <li>前 Toss Securities Data Scientist (2021)</li>
-          <li>前 Kakao Corp Data Scientist (2020)</li>
-          <li>성균관대학교 통계학 학사 졸업</li>
-          <li>F사 프로젝트 멘토/ 강사 (2020~2023)</li>
-          <li>N사 부스트 캠프 멘토/강사 (2022~2023)</li>
-          <li>S사 부트캠프 데이터 분석 멘토/강사 (2023~2024)</li>
-        </ul>
-      </div>
-      <div className="absolute bottom-[52px] h-[332px] flex flex-col gap-[39px] items-center justify-center w-full">
-        <div className="w-[237px] h-[93px] flex flex-col gap-[9px] justify-center items-center heading-3-semibold">
-          <div className="text-gradient">Session #1</div>
-          <div className="text-white">Data Scientist가 바라보는 AI의 지난 10년과 현재</div>
-        </div>
-        <div className="w-[295px] body-2-medium text-grey-200 text-left">
-          <p>
-            <span className="text-gradient">ChatGPT 3년차,</span> LLM은 더욱 어려운 문제를 해결하고
-            실제 작업을 수행하는 수준으로 발전했습니다.
-          </p>
-          <br />
-          <p>
-            코딩을 비롯한 다양한 분야에서 인간의 능력을 넘어서고, 연구 보고서도 쓰고, 혼자 티켓
-            예약도 할 수 있다는데요. <br />
-            <span className="text-gradient">LLM은 어쩌다 이렇게 똑똑해졌을까요?</span>
-          </p>
+        <div className="absolute bottom-[52px] h-[332px] flex flex-col gap-[39px] items-center justify-center w-full">
+          <div className="w-[237px] h-[93px] flex flex-col gap-[9px] justify-center items-center heading-3-semibold">
+            <div className="text-gradient">Session #1</div>
+            <div className="text-white">Data Scientist가 바라보는 AI의 지난 10년과 현재</div>
+          </div>
+          <div className="w-[295px] body-2-medium text-grey-200 text-left">
+            <p>
+              <span className="text-gradient">ChatGPT 3년차,</span> LLM은 더욱 어려운 문제를
+              해결하고 실제 작업을 수행하는 수준으로 발전했습니다.
+            </p>
+            <br />
+            <p>
+              코딩을 비롯한 다양한 분야에서 인간의 능력을 넘어서고, 연구 보고서도 쓰고, 혼자 티켓
+              예약도 할 수 있다는데요. <br />
+              <span className="text-gradient">LLM은 어쩌다 이렇게 똑똑해졌을까요?</span>
+            </p>
 
-          <br />
-          <p>
-            LLM의 놀라운 능력의 비밀,{' '}
-            <span className="text-gradient">추론(Reasoning)과 에이전트(Agent)</span>라는 핵심
-            키워드를 쉽고 명확하게 알아봅시다!
-          </p>
+            <br />
+            <p>
+              LLM의 놀라운 능력의 비밀,{' '}
+              <span className="text-gradient">추론(Reasoning)과 에이전트(Agent)</span>라는 핵심
+              키워드를 쉽고 명확하게 알아봅시다!
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default SeminarDetailLectureCard;

--- a/src/components/Seminar/SeminarDetailLectureCard.tsx
+++ b/src/components/Seminar/SeminarDetailLectureCard.tsx
@@ -1,63 +1,54 @@
-import { forwardRef } from 'react';
 import speakerEx from '../../assets/speakerEx.jpg';
 
-interface SeminarDetailLectureCardProps {
-  className?: string;
-}
-const SeminarDetailLectureCard = forwardRef<HTMLDivElement, SeminarDetailLectureCardProps>(
-  ({ className }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={`relative w-[335px] h-[1033px] rounded-[12px] overflow-hidden flex flex-col items-center justify-start ${className ?? ''}`}
-      >
-        <div className="absolute top-0 w-full h-[427px] top-gradient" />
-        <div className="absolute bottom-0 w-full h-[200px] bottom-gradient" />
-        <img src={speakerEx} alt="연사 이미지" className="w-[335px] h-[427px] object-cover " />
-        <div className="flex flex-col w-[295px] gap-[20px] items-center absolute top-[300px] ">
-          <div className="flex flex-col gap-4 justify-center items-center">
-            <div className="flex gap-[8px] items-center body-2-semibold text-white ">
-              연사 <span className="subhead-1-semibold text-gradient">김데브</span>님
-            </div>
-            <p className="body-1-medium text-white">前 Kakao · Toss Data Scientist</p>
+const SeminarDetailLectureCard = () => {
+  return (
+    <div className="relative w-[335px] h-[1033px] rounded-[12px] overflow-hidden flex flex-col items-center justify-start">
+      <div className="absolute top-0 w-full h-[427px] top-gradient" />
+      <div className="absolute bottom-0 w-full h-[200px] bottom-gradient" />
+      <img src={speakerEx} alt="연사 이미지" className="w-[335px] h-[427px] object-cover " />
+      <div className="flex flex-col w-[295px] gap-[20px] items-center absolute top-[300px] ">
+        <div className="flex flex-col gap-4 justify-center items-center">
+          <div className="flex gap-[8px] items-center body-2-semibold text-white ">
+            연사 <span className="subhead-1-semibold text-gradient">김데브</span>님
           </div>
-          <ul className="w-[273px] h-[140px] pl-5 body-2-medium text-grey-200 list-disc list-outside">
-            <li>前 Toss Securities Data Scientist (2021)</li>
-            <li>前 Kakao Corp Data Scientist (2020)</li>
-            <li>성균관대학교 통계학 학사 졸업</li>
-            <li>F사 프로젝트 멘토/ 강사 (2020~2023)</li>
-            <li>N사 부스트 캠프 멘토/강사 (2022~2023)</li>
-            <li>S사 부트캠프 데이터 분석 멘토/강사 (2023~2024)</li>
-          </ul>
+          <p className="body-1-medium text-white">前 Kakao · Toss Data Scientist</p>
         </div>
-        <div className="absolute bottom-[52px] h-[332px] flex flex-col gap-[39px] items-center justify-center w-full">
-          <div className="w-[237px] h-[93px] flex flex-col gap-[9px] justify-center items-center heading-3-semibold">
-            <div className="text-gradient">Session #1</div>
-            <div className="text-white">Data Scientist가 바라보는 AI의 지난 10년과 현재</div>
-          </div>
-          <div className="w-[295px] body-2-medium text-grey-200 text-left">
-            <p>
-              <span className="text-gradient">ChatGPT 3년차,</span> LLM은 더욱 어려운 문제를
-              해결하고 실제 작업을 수행하는 수준으로 발전했습니다.
-            </p>
-            <br />
-            <p>
-              코딩을 비롯한 다양한 분야에서 인간의 능력을 넘어서고, 연구 보고서도 쓰고, 혼자 티켓
-              예약도 할 수 있다는데요. <br />
-              <span className="text-gradient">LLM은 어쩌다 이렇게 똑똑해졌을까요?</span>
-            </p>
+        <ul className="w-[273px] h-[140px] pl-5 body-2-medium text-grey-200 list-disc list-outside">
+          <li>前 Toss Securities Data Scientist (2021)</li>
+          <li>前 Kakao Corp Data Scientist (2020)</li>
+          <li>성균관대학교 통계학 학사 졸업</li>
+          <li>F사 프로젝트 멘토/ 강사 (2020~2023)</li>
+          <li>N사 부스트 캠프 멘토/강사 (2022~2023)</li>
+          <li>S사 부트캠프 데이터 분석 멘토/강사 (2023~2024)</li>
+        </ul>
+      </div>
+      <div className="absolute bottom-[52px] h-[332px] flex flex-col gap-[39px] items-center justify-center w-full">
+        <div className="w-[237px] h-[93px] flex flex-col gap-[9px] justify-center items-center heading-3-semibold">
+          <div className="text-gradient">Session #1</div>
+          <div className="text-white">Data Scientist가 바라보는 AI의 지난 10년과 현재</div>
+        </div>
+        <div className="w-[295px] body-2-medium text-grey-200 text-left">
+          <p>
+            <span className="text-gradient">ChatGPT 3년차,</span> LLM은 더욱 어려운 문제를 해결하고
+            실제 작업을 수행하는 수준으로 발전했습니다.
+          </p>
+          <br />
+          <p>
+            코딩을 비롯한 다양한 분야에서 인간의 능력을 넘어서고, 연구 보고서도 쓰고, 혼자 티켓
+            예약도 할 수 있다는데요. <br />
+            <span className="text-gradient">LLM은 어쩌다 이렇게 똑똑해졌을까요?</span>
+          </p>
 
-            <br />
-            <p>
-              LLM의 놀라운 능력의 비밀,{' '}
-              <span className="text-gradient">추론(Reasoning)과 에이전트(Agent)</span>라는 핵심
-              키워드를 쉽고 명확하게 알아봅시다!
-            </p>
-          </div>
+          <br />
+          <p>
+            LLM의 놀라운 능력의 비밀,{' '}
+            <span className="text-gradient">추론(Reasoning)과 에이전트(Agent)</span>라는 핵심
+            키워드를 쉽고 명확하게 알아봅시다!
+          </p>
         </div>
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
 export default SeminarDetailLectureCard;

--- a/src/hooks/useIsVisible.tsx
+++ b/src/hooks/useIsVisible.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+export function useIsVisible<T extends HTMLElement>(ref: React.RefObject<T>): boolean {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const callback = (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+        } else {
+          setIsVisible(false);
+        }
+      });
+    };
+    const options = {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0.5,
+    };
+
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return isVisible;
+}

--- a/src/hooks/useIsVisible.tsx
+++ b/src/hooks/useIsVisible.tsx
@@ -18,7 +18,7 @@ export function useIsVisible<T extends HTMLElement>(ref: React.RefObject<T>): bo
     const options = {
       root: null,
       rootMargin: '0px',
-      threshold: 0.5,
+      threshold: 0.1,
     };
 
     const observer = new IntersectionObserver(callback, options);

--- a/src/hooks/useIsVisible.tsx
+++ b/src/hooks/useIsVisible.tsx
@@ -10,15 +10,14 @@ export function useIsVisible<T extends HTMLElement>(ref: React.RefObject<T>): bo
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
-        } else {
-          setIsVisible(false);
+          console.log('Visible');
         }
       });
     };
     const options = {
       root: null,
       rootMargin: '0px',
-      threshold: 0.1,
+      threshold: 0.2,
     };
 
     const observer = new IntersectionObserver(callback, options);

--- a/src/pages/user/seminar/Detail.tsx
+++ b/src/pages/user/seminar/Detail.tsx
@@ -5,29 +5,49 @@ import ReviewCard from '../../../components/common/ReviewCard';
 import Cta from '../../../components/common/Cta';
 import SeminarDetailLectureCard from '../../../components/Seminar/SeminarDetailLectureCard';
 import { useIsVisible } from '../../../hooks/useIsVisible';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const SeminarDetail = () => {
   const { id } = useParams();
-  const ref = useRef<HTMLDivElement>(null);
-  const isVisible = useIsVisible(ref as React.RefObject<HTMLDivElement>);
+  const lectureRef = useRef<HTMLDivElement>(null);
+  const secondRef = useRef<HTMLDivElement>(null);
+  const reviewRef = useRef<HTMLDivElement>(null);
+
+  const lectureVisible = useIsVisible(lectureRef as React.RefObject<HTMLDivElement>);
+  const secondVisible = useIsVisible(secondRef as React.RefObject<HTMLDivElement>);
+  const reviewVisible = useIsVisible(reviewRef as React.RefObject<HTMLDivElement>);
+
+  useEffect(() => {
+    if (secondVisible && secondRef.current) {
+      secondRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [secondVisible]);
 
   return (
     <div>
       <div className="flex flex-col gap-32 bg-balck">
         <Header />
         <SeminarDetailCard id={Number(id)} />
-        <div className="w-[375px] h-[2170px] flex flex-col gap-24 px-20">
+        <div
+          ref={lectureRef}
+          className={`w-[375px] h-[2170px] flex flex-col gap-24 px-20 transition-all duration-500 ease-out transform ${
+            lectureVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+          }`}
+        >
           <div className="heading-3-semibold text-white">연사 소개</div>
-          <div ref={ref} className="flex flex-col gap-10 justify-center items-center bg-black ">
-            <SeminarDetailLectureCard
-              ref={ref}
-              className={isVisible ? 'opacity-100 translate-y-0' : ''}
-            />
+          <div className="flex flex-col gap-10 justify-center items-center bg-black ">
             <SeminarDetailLectureCard />
+            <div ref={secondRef}>
+              <SeminarDetailLectureCard />{' '}
+            </div>
           </div>
         </div>
-        <div className="h-[475px] gap-12 px-20 flex flex-col">
+        <div
+          ref={reviewRef}
+          className={`transition-all duration-500 ease-out transform h-[475px] gap-12 px-20 flex flex-col ${
+            reviewVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+          }`}
+        >
           <div className="heading-3-semibold test-white">후기</div>
           <div className="w-[335px] h-[435px] flex flex-col gap-12">
             <ReviewCard session={Number(id)} rating={4} content="재밌어요" />

--- a/src/pages/user/seminar/Detail.tsx
+++ b/src/pages/user/seminar/Detail.tsx
@@ -4,9 +4,14 @@ import SeminarDetailCard from '../../../components/Seminar/SeminarDetailCard';
 import ReviewCard from '../../../components/common/ReviewCard';
 import Cta from '../../../components/common/Cta';
 import SeminarDetailLectureCard from '../../../components/Seminar/SeminarDetailLectureCard';
+import { useIsVisible } from '../../../hooks/useIsVisible';
+import React, { useRef } from 'react';
 
 const SeminarDetail = () => {
   const { id } = useParams();
+  const ref = useRef<HTMLDivElement>(null);
+  const isVisible = useIsVisible(ref as React.RefObject<HTMLDivElement>);
+
   return (
     <div>
       <div className="flex flex-col gap-32 bg-balck">
@@ -14,8 +19,11 @@ const SeminarDetail = () => {
         <SeminarDetailCard id={Number(id)} />
         <div className="w-[375px] h-[2170px] flex flex-col gap-24 px-20">
           <div className="heading-3-semibold text-white">연사 소개</div>
-          <div className="flex flex-col gap-10 justify-center items-center bg-black">
-            <SeminarDetailLectureCard />
+          <div ref={ref} className="flex flex-col gap-10 justify-center items-center bg-black ">
+            <SeminarDetailLectureCard
+              ref={ref}
+              className={isVisible ? 'opacity-100 translate-y-0' : ''}
+            />
             <SeminarDetailLectureCard />
           </div>
         </div>

--- a/src/pages/user/seminar/Detail.tsx
+++ b/src/pages/user/seminar/Detail.tsx
@@ -25,7 +25,7 @@ const SeminarDetail = () => {
 
   return (
     <div>
-      <div className="flex flex-col gap-32 bg-balck">
+      <div className="flex flex-col gap-32 bg-black">
         <Header />
         <SeminarDetailCard id={Number(id)} />
         <div
@@ -48,7 +48,7 @@ const SeminarDetail = () => {
             reviewVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
           }`}
         >
-          <div className="heading-3-semibold test-white">후기</div>
+          <div className="heading-3-semibold text-white">후기</div>
           <div className="w-[335px] h-[435px] flex flex-col gap-12">
             <ReviewCard session={Number(id)} rating={4} content="재밌어요" />
             <ReviewCard session={Number(id)} rating={5} content="유익한 세미나였습니다." />


### PR DESCRIPTION
## 🧾 관련 이슈
close : #125 


## 🔍 구현한 내용
세미나 상세 페이지 스크롤 이벤트 구현했습니다
* 요소들 하나씩 슬라이드인 
* 강연 소개 카드 첫 번째 설명 부분 끝에 왔을 때 다음 카드가 중앙으로 위치



## 📸 스크린샷(선택사항)

https://github.com/user-attachments/assets/9c4d05a2-432a-4e64-a399-dda43b72b08c




## 🙌 리뷰어에게
슬라이드인 속도나 언제 올라오는 지 등 타이밍 조정이 필요할 것 같다는 부분이 있다면 편하게 의견주세요 🙇‍♀️