### PR TITLE
[FIX] 어드민 레이아웃 오류 해결

### DIFF
--- a/src/layouts/admin/AdminLayout.tsx
+++ b/src/layouts/admin/AdminLayout.tsx
@@ -6,7 +6,7 @@ const AdminLayout: React.FC = () => {
   return (
     <div className="flex h-screen bg-background">
       <Sidebar />
-      <main className="flex-1 overflow-y-auto scrollbar-hide">
+      <main className="flex-1 overflow-y-auto scrollbar-hide min-w-fit">
         <Outlet />
       </main>
     </div>

--- a/src/layouts/admin/Sidebar.tsx
+++ b/src/layouts/admin/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, NavLink } from 'react-router-dom';
+import { Link, matchPath, NavLink, useLocation } from 'react-router-dom';
 import chevronup from '../../assets/icons/common/chevronup.svg';
 import chevrondown from '../../assets/icons/common/chevrondown.svg';
 import devlogo from '../../assets/logos/devlogo.svg';
@@ -16,7 +16,12 @@ const menuData = [
   {
     title: '세미나 관리',
     children: [
-      { name: '세미나 카드 조회', to: '/admin/seminars', end: true },
+      {
+        name: '세미나 카드 조회',
+        to: '/admin/seminars',
+        end: true,
+        matchPaths: ['/admin/seminars/:id'],
+      },
       { name: '세미나 추가하기', to: '/admin/seminars/add', end: true },
       { name: '세미나 신청자 관리', to: '/admin/seminars/applicants', end: false },
     ],
@@ -35,6 +40,19 @@ export const Sidebar: React.FC = () => {
   const [openSections, setOpenSections] = useState<string[]>(() =>
     menuData.map((section) => section.title)
   );
+
+  const { pathname } = useLocation();
+
+  // pathname이 matchPaths 패턴과 일치하는지 확인
+  const isPathMatching = (matchPaths?: string[]) => {
+    if (!matchPaths) return;
+
+    return matchPaths.some((pattern) => {
+      const regexPattern = `^${pattern.replace(/:id/g, '\\d+')}$`;
+      const regex = new RegExp(regexPattern);
+      return regex.test(pathname);
+    });
+  };
 
   const handleSectionClick = (title: string) => {
     if (openSections?.includes(title)) {
@@ -80,11 +98,13 @@ export const Sidebar: React.FC = () => {
                       <NavLink
                         to={item.to}
                         end={item.end}
-                        className={({ isActive }) =>
-                          `flex items-center h-[40px] py-3 px-[40px] cursor-pointer subhead-1-medium relative transition-colors ${
-                            isActive ? activeLinkStyle : inactiveLinkStyle
-                          }`
-                        }
+                        className={({ isActive }) => {
+                          let finalIsActive = isActive || isPathMatching(item.matchPaths);
+
+                          return `flex items-center h-[40px] py-3 px-[40px] cursor-pointer subhead-1-medium relative transition-colors ${
+                            finalIsActive ? activeLinkStyle : inactiveLinkStyle
+                          }`;
+                        }}
                       >
                         {item.name}
                       </NavLink>

--- a/src/layouts/admin/Sidebar.tsx
+++ b/src/layouts/admin/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, matchPath, NavLink, useLocation } from 'react-router-dom';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import chevronup from '../../assets/icons/common/chevronup.svg';
 import chevrondown from '../../assets/icons/common/chevrondown.svg';
 import devlogo from '../../assets/logos/devlogo.svg';

--- a/src/layouts/admin/Sidebar.tsx
+++ b/src/layouts/admin/Sidebar.tsx
@@ -23,9 +23,7 @@ const menuData = [
   },
   {
     title: '세미나 Live 관리',
-    children: [
-      { name: '출석 관리', to: '/admin/seminar-live/attendance', end: true },
-    ],
+    children: [{ name: '출석 관리', to: '/admin/seminar-live/attendance', end: true }],
   },
   {
     title: '관리자 권한 관리',
@@ -51,7 +49,7 @@ export const Sidebar: React.FC = () => {
   const inactiveLinkStyle = 'text-grey-300';
 
   return (
-    <aside className="w-[290px] text-white bg-grey-900 flex flex-col">
+    <aside className="w-[290px] text-white bg-grey-900 flex flex-col flex-shrink-0">
       {/* 로고 */}
       <Link className="flex items-center justify-center gap-5 h-[80px]" to="/admin/home/promo">
         <img src={devlogo} alt="devlogo" className="w-80 h-9" />


### PR DESCRIPTION
## 🧾 관련 이슈
close : #133 


## 🔍 구현한 내용

좁은 화면에서의 어드민 레이아웃의 깨짐 현상을 해결했습니다.
세미나 상세정보 관리 페이지에서 sidebar의 세미나 카드 조회가 활성화 되도록 수정했습니다.


## 📸 스크린샷(선택사항)


https://github.com/user-attachments/assets/d01be44e-804b-47b5-b87e-212fd1a57207


<img width="1558" height="943" alt="image" src="https://github.com/user-attachments/assets/c293e410-a812-4b0b-b936-00e9afcc40c0" />




## 🙌 리뷰어에게
