### PR TITLE
Feature/#135 admin seminar card api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.13",
+        "@tanstack/react-query": "^5.90.2",
+        "@tanstack/react-query-devtools": "^5.90.2",
         "axios": "^1.12.2",
         "pretendard": "^1.3.9",
         "react": "^19.1.1",
@@ -2038,6 +2040,59 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.90.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
+      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
+      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.90.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.13",
+    "@tanstack/react-query": "^5.90.2",
+    "@tanstack/react-query-devtools": "^5.90.2",
     "axios": "^1.12.2",
     "pretendard": "^1.3.9",
     "react": "^19.1.1",

--- a/src/apis/SeminarCard/seminarCardApi.ts
+++ b/src/apis/SeminarCard/seminarCardApi.ts
@@ -1,0 +1,7 @@
+import type { SeminarListResponse } from '../../types/SeminarManage/seminarCard.api';
+import { adminInstance } from '../adminInstance';
+
+export const getSeminarCard = async (): Promise<SeminarListResponse> => {
+  const res = await adminInstance.get<SeminarListResponse>('/admin/seminars/card');
+  return res.data;
+};

--- a/src/components/admin/seminar-manage/SeminarCard/SeminarCard.tsx
+++ b/src/components/admin/seminar-manage/SeminarCard/SeminarCard.tsx
@@ -1,46 +1,51 @@
 import { Link } from 'react-router-dom';
 import { formatDate } from '../../../../utils/formatDate';
-
-interface Seminar {
-  id: number;
-  title: string;
-  date: string;
-  location: string;
-  topic: string;
-}
+import type { SeminarCardData } from '../../../../types/SeminarManage/seminarCard.api';
 
 interface SeminarCardProps {
-  seminar: Seminar;
+  seminar: SeminarCardData;
 }
 
 const SeminarCard = ({ seminar }: SeminarCardProps) => {
   return (
-    <Link to={`/admin/seminars/${seminar.id}`}>
+    <Link to={`/admin/seminars/${seminar.seminarNum}`}>
       <div className="bg-grey-700 max-w-[450px] rounded-lg p-3 cursor-pointer transition-colors border border-transparent hover:border-green-300 hover:bg-grey-600 duration-300">
         {/* 세미나 정보 */}
-        <h2 className="heading-2-bold mb-1 text-center">{seminar.title}</h2>
+        <h2 className="heading-2-bold mb-1 text-center">{`제 ${seminar.seminarNum}회 Devtalk Seminar`}</h2>
 
         <div className="flex space-x-5">
           {/* 이미지 */}
-          <div className="w-[220px] h-[160px] bg-grey-100 rounded-md my-auto"></div>
+          <div className="w-[220px] h-[160px] bg-grey-100 rounded-md my-auto overflow-hidden">
+            {seminar.imageUrl ? (
+              <img
+                src={seminar.imageUrl}
+                alt={`${seminar.seminarTopic}썸네일`}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-grey-500 caption-semibold">
+                No Image
+              </div>
+            )}
+          </div>
 
           <div className="flex flex-col mt-[16px] flex-1 min-w-0">
             <div className="mb-[16px]">
               <p className="body-2-semibold mb-[8px] text-grey-300">일정</p>
               <div className="caption-semibold w-full verflow-hidden whitespace-nowrap text-ellipsis">
-                {formatDate(seminar.date)}
+                {formatDate(seminar.seminarDate)}
               </div>
             </div>
             <div className="mb-[16px]">
               <p className="body-2-semibold mb-[8px] text-grey-300">장소</p>
               <div className="caption-semibold w-full overflow-hidden whitespace-nowrap text-ellipsis">
-                {seminar.location}
+                {seminar.place}
               </div>
             </div>
             <div className="mb-[16px]">
               <p className="body-2-semibold mb-[8px] text-grey-300">주제</p>
               <div className="caption-semibold w-full overflow-hidden whitespace-nowrap text-ellipsis">
-                {seminar.topic}
+                {seminar.seminarTopic}
               </div>
             </div>
           </div>

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEYS = {
+  ADMIN_SEMINAR_CARDS: 'amdinSeminarCards',
+};

--- a/src/hooks/SeminarManage/useSeminarCards.ts
+++ b/src/hooks/SeminarManage/useSeminarCards.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import type { SeminarListResponse } from '../../types/SeminarManage/seminarCard.api';
+import { getSeminarCard } from '../../apis/SeminarCard/seminarCardApi';
+import { QUERY_KEYS } from '../../constants/queryKey';
+
+// 세미나 카드 조회
+export const useSeminarCards = () => {
+  return useQuery<SeminarListResponse>({
+    queryKey: [QUERY_KEYS.ADMIN_SEMINAR_CARDS],
+    queryFn: getSeminarCard,
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import ReactQueryProvider from './utils/ReactQueryProvider.tsx';
 import './index.css';
 import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ReactQueryProvider>
+      <App />
+    </ReactQueryProvider>
   </StrictMode>
 );

--- a/src/pages/admin/seminar-manage/Cards.tsx
+++ b/src/pages/admin/seminar-manage/Cards.tsx
@@ -1,60 +1,22 @@
 import { Link } from 'react-router-dom';
 import SeminarCard from '../../../components/admin/seminar-manage/SeminarCard/SeminarCard';
-
-// mock data
-const mockSeminars = [
-  {
-    id: 10,
-    title: '제 10회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-  {
-    id: 9,
-    title: '제 9회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-  {
-    id: 8,
-    title: '제 8회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-  {
-    id: 7,
-    title: '제 7회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-  {
-    id: 6,
-    title: '제 6회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-  {
-    id: 5,
-    title: '제 5회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-  {
-    id: 4,
-    title: '제 4회 Devtalk Seminar',
-    date: '2025-10-04T19:00:00',
-    location: '가나다라마바사',
-    topic: '아자차카타파하에이비씨디이에프지에이치아이엘엠엔오피',
-  },
-];
+import { useSeminarCards } from '../../../hooks/SeminarManage/useSeminarCards';
 
 const Cards = () => {
+  const { data: seminarData, isLoading, isError } = useSeminarCards();
+
+  if (isLoading) {
+    return <div className="text-white text-center p-20">데이터를 불러오는 중입니다...</div>;
+  }
+
+  if (isError) {
+    return (
+      <div className="text-status-error text-center p-20">데이터를 불러오는 데 실패했습니다.</div>
+    );
+  }
+
+  const seminars = seminarData?.result?.seminarList || [];
+
   return (
     <div className="min-w-[900px] max-w-[950px] py-[60px] px-[30px]">
       {/* 헤더 */}
@@ -67,8 +29,8 @@ const Cards = () => {
 
       {/* 세미나 카드 */}
       <div className="grid grid-cols-2 gap-[25px]">
-        {mockSeminars.map((seminar) => (
-          <SeminarCard key={seminar.id} seminar={seminar} />
+        {seminars.map((seminar) => (
+          <SeminarCard key={seminar.seminarNum} seminar={seminar} />
         ))}
       </div>
     </div>

--- a/src/types/SeminarManage/seminarCard.api.ts
+++ b/src/types/SeminarManage/seminarCard.api.ts
@@ -1,0 +1,15 @@
+import type { CommonResponse } from '../common';
+
+export interface SeminarCardData {
+  seminarNum: number;
+  seminarTopic: string;
+  seminarDate: string;
+  place: string;
+  imageUrl: string;
+}
+
+export interface SeminarListResult {
+  seminarList: SeminarCardData[];
+}
+
+export type SeminarListResponse = CommonResponse<SeminarListResult>;

--- a/src/utils/ReactQueryProvider.tsx
+++ b/src/utils/ReactQueryProvider.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+export default function ReactQueryProvider({ children }: React.PropsWithChildren) {
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          refetchOnMount: false,
+          retry: 2,
+        },
+      },
+    })
+  );
+
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## 🧾 관련 이슈
close : #135 


## 🔍 구현한 내용

어드민의 세미나 카드 페이지 API를 연동했습니다,


## 📸 스크린샷(선택사항)

<img width="1265" height="943" alt="image" src="https://github.com/user-attachments/assets/9055ee98-d89e-44d8-b10e-28419fc64cbd" />




## 🙌 리뷰어에게
- Tanstack Query 라이브러리를 설치했습니다.
- 리뷰하실 때,`admin/login`에서 로그인 후, 세미나 카드 조회 페이지 접속 부탁드립니다!
- 세미나 카드 조회 API 로직은 `hooks/SeminarManage/useSeminarCards.ts`에 분리했습니다. 
(좋은 방법이 있으시다면, 편하게 의견 주시면 감사하겠습니다!)
- Tanstack Query에서 불필요한 API 요청을 줄이고자, refetchOnWindowFocus, refetchOnMount를 둘다 전역적으로 false로 설정했는데 전역적으로는 true로 설정하는게 좋을지 의견 부탁드립니다!