### PR TITLE
Feature/#144 user refresh token

### DIFF
--- a/src/apis/userInstance.ts
+++ b/src/apis/userInstance.ts
@@ -5,6 +5,10 @@ export const userInstance: AxiosInstance = axios.create({
   baseURL: import.meta.env.VITE_SERVER_API_URL,
 });
 
+export const userRefreshInstance: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_SERVER_API_URL,
+});
+
 userInstance.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem(STORAGE_KEY.USER_ACCESS_TOKEN);
@@ -26,12 +30,48 @@ userInstance.interceptors.response.use(
 
     if (!status) return Promise.reject(status);
 
+    //토큰 만료 오류
+    if (status === 419 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const refreshToken = localStorage.getItem(STORAGE_KEY.USER_REFRESH_TOKEN);
+
+      //refreshToken이 없는 경우 세미나 인증 페이지로 이동
+      if (!refreshToken) {
+        localStorage.removeItem(STORAGE_KEY.USER_ACCESS_TOKEN);
+        window.location.href = 'seminar/live/verification';
+        return Promise.reject(error);
+      }
+
+      //refreshToken으로 새 accessToken 발급
+      try {
+        const oldToken = localStorage.getItem(STORAGE_KEY.USER_ACCESS_TOKEN);
+        const { data } = await userRefreshInstance.post('/user/live/reissue', {
+          accessToken: oldToken,
+          refreshToken: refreshToken,
+        });
+
+        const newAccessToken = data?.accessToken;
+        const newRefreshToken = data?.refreshToken;
+
+        localStorage.setItem(STORAGE_KEY.ADMIN_ACCESS_TOKEN, newAccessToken);
+        localStorage.setItem(STORAGE_KEY.ADMIN_REFRESH_TOKEN, newRefreshToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return userInstance(originalRequest);
+      } catch (error) {
+        //에러 발생시 세미나 인증 페이지으로 이동
+        localStorage.removeItem(STORAGE_KEY.ADMIN_ACCESS_TOKEN);
+        localStorage.removeItem(STORAGE_KEY.ADMIN_REFRESH_TOKEN);
+        window.location.replace('/seminar/live/verification');
+      }
+    }
+
     //토큰 오류
     if (status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
-      //홈으로 이동
+      //세미나 인증 페이지로 이동
       localStorage.removeItem(STORAGE_KEY.USER_ACCESS_TOKEN);
-      window.location.href = '/';
+      window.location.href = '/seminar/live/verification';
       return Promise.reject(error);
     }
 

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -2,4 +2,5 @@ export const STORAGE_KEY = {
   ADMIN_ACCESS_TOKEN: 'adminAccessToken',
   ADMIN_REFRESH_TOKEN: 'adminRefreshToken',
   USER_ACCESS_TOKEN: 'userAccessToken',
+  USER_REFRESH_TOKEN: 'userRefreshToken',
 };


### PR DESCRIPTION
## 🧾 관련 이슈
close : #144 


## 🔍 구현한 내용
user refreshToken으로 accessToken 재발급 받는 로직 추가했습니다


## 📸 스크린샷(선택사항)





## 🙌 리뷰어에게
이전에는 토큰이 만료되거나 유효하지 않은 경우 홈으로 리다이렉트하도록 되어 있었는데, 이번 수정에서는 유저 측 세미나 인증 플로우를 고려해 홈보다는 세미나 신청자 인증 페이지로 리다이렉트 하는 게 좋을 것 같아 변경했습니다!

현재 플로우는

* 세미나 유저 인증 페이지에서 학번 인증 후 토큰 발급
* 이후 세미나 보러가기, 후기 남기기 페이지로 이동

이렇게 되어 있는데, 실제로 토큰이 필요한 시점은 세미나 입장이나 후기 작성 뿐이라 홈보다는 인증 페이지로 보내는 편이 더 좋을 것 같다고 판단했습니다!

이 방향이 괜찮을지, 혹은 다른 의견이 있으신지도 확인 부탁드립니다!
