### PR TITLE
[FEAT] 어드민 신청자 관리 페이지 API 연동

### DIFF
--- a/src/apis/Applicants/seminarApplicantsDetailApi.ts
+++ b/src/apis/Applicants/seminarApplicantsDetailApi.ts
@@ -1,0 +1,11 @@
+import type { SeminarApplicantsDetailResponse } from '../../types/Applicants/seminarApplicantsDetail.api';
+import { adminInstance } from '../adminInstance';
+
+export const getSeminarApplicantsDetail = async (
+  seminarId: string
+): Promise<SeminarApplicantsDetailResponse> => {
+  const res = await adminInstance.get<SeminarApplicantsDetailResponse>(
+    `/admin/seminars/${seminarId}/applicants`
+  );
+  return res.data;
+};

--- a/src/apis/Applicants/seminarNumsApi.ts
+++ b/src/apis/Applicants/seminarNumsApi.ts
@@ -1,0 +1,7 @@
+import type { SeminarNumsResponse } from '../../types/Applicants/seminarNums.api';
+import { adminInstance } from '../adminInstance';
+
+export const getSeminarNums = async (): Promise<SeminarNumsResponse> => {
+  const res = await adminInstance.get<SeminarNumsResponse>('/admin/seminars/nums');
+  return res.data;
+};

--- a/src/apis/Applicants/seminarQuestionsApi.ts
+++ b/src/apis/Applicants/seminarQuestionsApi.ts
@@ -1,0 +1,11 @@
+import type { SeminarQuestionsResponse } from '../../types/Applicants/seminarQuestions.api';
+import { adminInstance } from '../adminInstance';
+
+export const getSeminarQuestions = async (
+  seminarId: string
+): Promise<SeminarQuestionsResponse> => {
+  const res = await adminInstance.get<SeminarQuestionsResponse>(
+    `/admin/seminars/${seminarId}/questions`
+  );
+  return res.data;
+};

--- a/src/components/admin/applicants/ApplicantsList.tsx
+++ b/src/components/admin/applicants/ApplicantsList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSeminarNums } from '../../../hooks/Applicants/useSeminarNums';
 
 // 세미나 데이터 타입 정의
 interface SeminarData {
@@ -8,17 +9,13 @@ interface SeminarData {
 
 const ApplicantsList = () => {
   const navigate = useNavigate();
+  const { data: seminarNumsData } = useSeminarNums();
 
-  // 세미나 목록 목데이터 (API 연동 시 이 부분을 fetch로 교체)
-  const seminars: SeminarData[] = [
-    { id: 10 },
-    { id: 9 },
-    { id: 8 },
-    { id: 7 },
-    { id: 6 },
-    { id: 5 },
-    { id: 4 },
-  ];
+  // API 응답에서 세미나 번호 추출 및 내림차순 정렬
+  const seminars: SeminarData[] =
+    seminarNumsData?.result?.seminarNums
+      ?.map((num) => ({ id: num }))
+      .sort((a, b) => b.id - a.id) || [];
 
   // 세미나 제목 생성 함수
   const getSeminarTitle = (id: number) => `제 ${id}회 Devtalk Seminar`;

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -1,4 +1,7 @@
 export const QUERY_KEYS = {
   ADMIN_SEMINAR_CARDS: 'amdinSeminarCards',
   ADMIN_HOME_IMAGES: 'adminHomeImages',
+  ADMIN_SEMINAR_NUMS: 'adminSeminarNums',
+  ADMIN_SEMINAR_APPLICANTS_DETAIL: 'adminSeminarApplicantsDetail',
+  ADMIN_SEMINAR_QUESTIONS: 'adminSeminarQuestions',
 };

--- a/src/hooks/Applicants/useSeminarApplicantsDetail.ts
+++ b/src/hooks/Applicants/useSeminarApplicantsDetail.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import type { SeminarApplicantsDetailResponse } from '../../types/Applicants/seminarApplicantsDetail.api';
+import { getSeminarApplicantsDetail } from '../../apis/Applicants/seminarApplicantsDetailApi';
+import { QUERY_KEYS } from '../../constants/queryKey';
+
+// 세미나별 신청자 상세 정보 조회
+export const useSeminarApplicantsDetail = (seminarId: string) => {
+  return useQuery<SeminarApplicantsDetailResponse>({
+    queryKey: [QUERY_KEYS.ADMIN_SEMINAR_APPLICANTS_DETAIL, seminarId],
+    queryFn: () => getSeminarApplicantsDetail(seminarId),
+    enabled: !!seminarId,
+  });
+};

--- a/src/hooks/Applicants/useSeminarNums.ts
+++ b/src/hooks/Applicants/useSeminarNums.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import type { SeminarNumsResponse } from '../../types/Applicants/seminarNums.api';
+import { getSeminarNums } from '../../apis/Applicants/seminarNumsApi';
+import { QUERY_KEYS } from '../../constants/queryKey';
+
+// 세미나 번호 목록 조회
+export const useSeminarNums = () => {
+  return useQuery<SeminarNumsResponse>({
+    queryKey: [QUERY_KEYS.ADMIN_SEMINAR_NUMS],
+    queryFn: getSeminarNums,
+  });
+};

--- a/src/hooks/Applicants/useSeminarQuestions.ts
+++ b/src/hooks/Applicants/useSeminarQuestions.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import type { SeminarQuestionsResponse } from '../../types/Applicants/seminarQuestions.api';
+import { getSeminarQuestions } from '../../apis/Applicants/seminarQuestionsApi';
+import { QUERY_KEYS } from '../../constants/queryKey';
+
+// 세미나별 연사 질문 조회
+export const useSeminarQuestions = (seminarId: string) => {
+  return useQuery<SeminarQuestionsResponse>({
+    queryKey: [QUERY_KEYS.ADMIN_SEMINAR_QUESTIONS, seminarId],
+    queryFn: () => getSeminarQuestions(seminarId),
+    enabled: !!seminarId,
+  });
+};

--- a/src/pages/admin/seminar-manage/applicants/Detail.tsx
+++ b/src/pages/admin/seminar-manage/applicants/Detail.tsx
@@ -2,253 +2,40 @@ import { useParams } from 'react-router-dom';
 import ApplicantsDetailList from './../../../../components/admin/applicants/ApplicantsDetailList';
 import BackButton from './../../../../components/Button/BackButton';
 import ExcelDownloadButton from './../../../../components/Button/ExcelDownloadButton';
+import { useSeminarApplicantsDetail } from '../../../../hooks/Applicants/useSeminarApplicantsDetail';
 
 const Detail = () => {
   const { id } = useParams<{ id: string }>();
+  const { data: applicantsData } = useSeminarApplicantsDetail(id!);
 
-  // 세미나 ID별 신청자 데이터 가져오기
-  const getMockApplicantsBySeminarId = (seminarId: string) => {
-    const mockData: { [key: string]: any[] } = {
-      '10': [
-        {
-          id: 1,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C11111',
-          department: '컴퓨터공학과',
-          grade: '3',
-          name: '홍길동',
-          contact: '010-1234-5678',
-          email: 'hong@example.com',
-          attendanceType: '온라인',
-          referralSource: '인스타그램',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 10회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        }
-      ],
-      '9': [
-        {
-          id: 1,
-          seminarName: '제 9회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        },
-        {
-          id: 2,
-          seminarName: '제 9회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        }
-      ],
-      '7': [
-        {
-          id: 1,
-          seminarName: '제 7회 devtalk seminar',
-          studentId: 'C22222',
-          department: '소프트웨어학부',
-          grade: '2',
-          name: '김영희',
-          contact: '010-2345-6789',
-          email: 'kim@example.com',
-          attendanceType: '오프라인',
-          referralSource: '에브리타임',
-        }
-      ]
+  // inflowPath 매핑 함수
+  const getInflowPathLabel = (inflowPath: string) => {
+    const inflowPathMap: { [key: string]: string } = {
+      FRIEND: '지인',
+      PROFESSOR: '교수님 추천',
+      EVERYTIME: '에브리타임',
+      DEPARTMENT: '학과 공지방',
+      CLUB: '학회/동아리 공지방',
+      CAMPUS: '교내 포스터 / X배너',
+      INSTAGRAM: '인스타그램',
     };
-
-    return mockData[seminarId] || [];
+    return inflowPathMap[inflowPath] || inflowPath;
   };
 
-  const mockApplicants = getMockApplicantsBySeminarId(id!);
+  // API 응답 데이터를 컴포넌트에서 사용하는 형식으로 변환
+  const applicants =
+    applicantsData?.result?.map((applicant, index) => ({
+      id: index + 1,
+      seminarName: applicant.topic,
+      studentId: applicant.studentNum,
+      department: applicant.department,
+      grade: applicant.grade,
+      name: applicant.name,
+      contact: applicant.phone,
+      email: applicant.email,
+      attendanceType: applicant.participationType === 'ONLINE' ? '온라인' : '오프라인',
+      referralSource: getInflowPathLabel(applicant.inflowPath),
+    })) || [];
 
   const getSeminarTitle = (id: string) => `제 ${id}회 Devtalk Seminar`;
 
@@ -273,14 +60,14 @@ const Detail = () => {
           <h1 className="text-white heading-1-bold">{getSeminarTitle(id!)}-신청자 개인정보</h1>
         </div>
         <ExcelDownloadButton
-          data={mockApplicants}
+          data={applicants}
           fileName={`${getSeminarTitle(id!)}_신청자_개인정보.xlsx`}
           className="subhead-1-semibold"
           headers={excelHeaders}
         />
       </div>
       <div className="ml-[21.5px]">
-        <ApplicantsDetailList applicants={mockApplicants} />
+        <ApplicantsDetailList applicants={applicants} />
       </div>
     </div>
   );

--- a/src/pages/admin/seminar-manage/applicants/Questions.tsx
+++ b/src/pages/admin/seminar-manage/applicants/Questions.tsx
@@ -2,78 +2,33 @@ import { useParams } from 'react-router-dom';
 import ApplicantsQuestionList from './../../../../components/admin/applicants/ApplicantsQuestionList';
 import BackButton from './../../../../components/Button/BackButton';
 import ExcelDownloadButton from './../../../../components/Button/ExcelDownloadButton';
+import { useSeminarQuestions } from '../../../../hooks/Applicants/useSeminarQuestions';
 
 const Questions = () => {
   const { id } = useParams<{ id: string }>();
+  const { data: questionsData } = useSeminarQuestions(id!);
 
-  // mockdata
-  const getMockQuestionsBySeminarId = (seminarId: string) => {
-    const mockData: { [key: string]: any } = {
-      '10': {
-        seminarTitle: '제 10회 Devtalk Seminar',
-        speakers: {
-          speaker1: '김00',
-          speaker2: '박00'
-        },
-        applicants: [
-          {
-            id: 1,
-            studentId: 'C11111',
-            name: '홍길동',
-            contact: '010-1234-5678',
-            question1: '개발자로서 가장 중요하게 생각하는 덕목은 무엇인가요?',
-            question2: '현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?',
-          },
-          {
-            id: 2,
-            studentId: 'C22222',
-            name: '김영희',
-            contact: '010-2345-6789',
-            question1: '프론트엔드 개발에서 가장 어려운 부분은 무엇인가요?',
-            question2: '개발자로서의 성장을 위해 어떤 노력을 하고 계신가요?',
-          },
-        ]
-      },
-      '9': {
-        seminarTitle: '제 9회 Devtalk Seminar',
-        speakers: {
-          speaker1: '이oo',
-          speaker2: '최oo'
-        },
-        applicants: [
-          {
-            id: 1,
-            studentId: 'C11111',
-            name: '홍길동',
-            contact: '010-1234-5678',
-            question1: '개발자로서 가장 중요하게 생각하는 덕목은 무엇인가요?',
-            question2: '현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?',
-          },
-        ]
-      },
-      '7': {
-        seminarTitle: '제 7회 Devtalk Seminar',
-        speakers: {
-          speaker1: '정oo',
-          speaker2: '한oo'
-        },
-        applicants: [
-          {
-            id: 1,
-            studentId: 'C11111',
-            name: '홍길동',
-            contact: '010-1234-5678',
-            question1: '개발자로서 가장 중요하게 생각하는 덕목은 무엇인가요?',
-            question2: '현재 사용하고 계신 기술 스택 중 가장 만족스러운 것은 무엇인가요?',
-          },
-        ]
-      }
-    };
+  // API 응답 데이터를 컴포넌트에서 사용하는 형식으로 변환
+  const speakers = questionsData?.result?.speakers || [];
+  const applicants =
+    questionsData?.result?.students?.map((student, index) => {
+      const question1 = student.questions.find((q) => q.speakerId === speakers[0]?.speakerId);
+      const question2 = student.questions.find((q) => q.speakerId === speakers[1]?.speakerId);
 
-    return mockData[seminarId] || { seminarTitle: '', speakers: { speaker1: '', speaker2: '' }, applicants: [] };
+      return {
+        id: index + 1,
+        studentId: student.studentNum,
+        name: student.studentName,
+        contact: student.phoneNum,
+        question1: question1?.content || '',
+        question2: question2?.content || '',
+      };
+    }) || [];
+
+  const speakersInfo = {
+    speaker1: speakers[0]?.speakerName || '첫번째 연사',
+    speaker2: speakers[1]?.speakerName || '두번째 연사',
   };
-
-  const mockQuestions = getMockQuestionsBySeminarId(id!);
 
   const getSeminarTitle = (id: string) => `제 ${id}회 Devtalk Seminar`;
 
@@ -82,8 +37,8 @@ const Questions = () => {
     studentId: '학번',
     name: '이름',
     contact: '연락처',
-    question1: `[${mockQuestions.speakers?.speaker1 || '첫번째 연사'}]님께 궁금한 점이나 듣고 싶은 이야기가 있나요?`,
-    question2: `[${mockQuestions.speakers?.speaker2 || '두번째 연사'}]님께 궁금한 점이나 듣고 싶은 이야기가 있나요?`
+    question1: `[${speakersInfo.speaker1}]님께 궁금한 점이나 듣고 싶은 이야기가 있나요?`,
+    question2: `[${speakersInfo.speaker2}]님께 궁금한 점이나 듣고 싶은 이야기가 있나요?`
   };
 
   return (
@@ -94,14 +49,14 @@ const Questions = () => {
           <h1 className="text-white heading-1-bold">{getSeminarTitle(id!)}-연사별 질문</h1>
         </div>
         <ExcelDownloadButton
-          data={mockQuestions.applicants}
+          data={applicants}
           fileName={`${getSeminarTitle(id!)}_연사별_질문.xlsx`}
           className="subhead-1-semibold"
           headers={excelHeaders}
         />
       </div>
       <div className="ml-[21.5px]">
-        <ApplicantsQuestionList applicants={mockQuestions.applicants} speakers={mockQuestions.speakers} />
+        <ApplicantsQuestionList applicants={applicants} speakers={speakersInfo} />
       </div>
     </div>
   );

--- a/src/types/Applicants/seminarApplicantsDetail.api.ts
+++ b/src/types/Applicants/seminarApplicantsDetail.api.ts
@@ -1,0 +1,16 @@
+import type { CommonResponse } from '../common';
+
+export interface ApplicantData {
+  topic: string;
+  studentId: string;
+  studentNum: string;
+  department: string;
+  grade: string;
+  name: string;
+  phone: string;
+  email: string;
+  participationType: 'ONLINE' | 'OFFLINE';
+  inflowPath: string;
+}
+
+export type SeminarApplicantsDetailResponse = CommonResponse<ApplicantData[]>;

--- a/src/types/Applicants/seminarNums.api.ts
+++ b/src/types/Applicants/seminarNums.api.ts
@@ -1,0 +1,7 @@
+import type { CommonResponse } from '../common';
+
+export interface SeminarNumsResult {
+  seminarNums: number[];
+}
+
+export type SeminarNumsResponse = CommonResponse<SeminarNumsResult>;

--- a/src/types/Applicants/seminarQuestions.api.ts
+++ b/src/types/Applicants/seminarQuestions.api.ts
@@ -1,0 +1,26 @@
+import type { CommonResponse } from '../common';
+
+export interface Speaker {
+  speakerId: number;
+  speakerName: string;
+}
+
+export interface Question {
+  speakerId: number;
+  content: string;
+}
+
+export interface Student {
+  studentId: number;
+  studentNum: string;
+  studentName: string;
+  phoneNum: string;
+  questions: Question[];
+}
+
+export interface SeminarQuestionsResult {
+  speakers: Speaker[];
+  students: Student[];
+}
+
+export type SeminarQuestionsResponse = CommonResponse<SeminarQuestionsResult>;


### PR DESCRIPTION
## 🧾 관련 이슈
close : #157 


## 🔍 구현한 내용
어드민 신청자 관리 페이지 API 연동했습니다. 스웨거 문서 기준 [Admin]Seminar 의 세미나 회차 리스트, 세미나 신청자 정보, 세미나 연사별 질문 조회 api 연결했습니다. 


## 📸 스크린샷(선택사항)
<img width="1918" height="1013" alt="image" src="https://github.com/user-attachments/assets/f347d093-98d4-46c0-876b-be591558b7d6" />

<img width="1917" height="967" alt="image" src="https://github.com/user-attachments/assets/ed838aaa-9e3d-48bd-be06-d0f618668eb2" />

<img width="1918" height="992" alt="image" src="https://github.com/user-attachments/assets/eb13934d-aacc-43f1-8997-3d21ce125a42" />


## 🙌 리뷰어에게
세미나 1회차에 데이터가 다 들어가 있어서 세미나 1회 중심으로 확인해주시면 감사할 것 같습니당