### PR TITLE
 [CHORE] 세미나 상세 페이지 CTA props 받도록 변경

### DIFF
--- a/src/pages/user/seminar/Detail.tsx
+++ b/src/pages/user/seminar/Detail.tsx
@@ -1,11 +1,11 @@
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import Header from '../../../components/common/Header';
 import SeminarDetailCard from '../../../components/Seminar/SeminarDetailCard';
 import ReviewCard from '../../../components/common/ReviewCard';
 import Cta from '../../../components/common/Cta';
 import SeminarDetailLectureCard from '../../../components/Seminar/SeminarDetailLectureCard';
 import { useIsVisible } from '../../../hooks/useIsVisible';
-import React, { useEffect, useRef } from 'react';
+import React, { use, useEffect, useRef } from 'react';
 
 const SeminarDetail = () => {
   const { id } = useParams();
@@ -17,6 +17,7 @@ const SeminarDetail = () => {
   const secondVisible = useIsVisible(secondRef as React.RefObject<HTMLDivElement>);
   const reviewVisible = useIsVisible(reviewRef as React.RefObject<HTMLDivElement>);
 
+  const navigate = useNavigate();
   useEffect(() => {
     if (secondVisible && secondRef.current) {
       secondRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -57,7 +58,11 @@ const SeminarDetail = () => {
         </div>
       </div>
       <div className="fixed bottom-0">
-        <Cta />
+        <Cta
+          bodyText="데브톡에 빠져보세요!"
+          buttonText="10회차 데브톡 신청하기"
+          onClick={() => navigate('/seminar/apply-info')}
+        />
       </div>
       <div className="h-[250px]" />
     </div>

--- a/src/pages/user/seminar/Detail.tsx
+++ b/src/pages/user/seminar/Detail.tsx
@@ -5,7 +5,7 @@ import ReviewCard from '../../../components/common/ReviewCard';
 import Cta from '../../../components/common/Cta';
 import SeminarDetailLectureCard from '../../../components/Seminar/SeminarDetailLectureCard';
 import { useIsVisible } from '../../../hooks/useIsVisible';
-import React, { use, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 const SeminarDetail = () => {
   const { id } = useParams();


### PR DESCRIPTION
## 🧾 관련 이슈
close : #161 


## 🔍 구현한 내용
배포 빌드시 세미나 상세 페이지 오류를 수정했습니다
CTA 컴포넌트를 props로 받도록 변경됨에 따라서 해당 페이지에서도 수정했습니다.


## 📸 스크린샷(선택사항)





## 🙌 리뷰어에게
