### PR TITLE
[FEAT] 세미나 리뷰작성 api 연결

### DIFF
--- a/src/apis/seminarReview.ts
+++ b/src/apis/seminarReview.ts
@@ -1,0 +1,19 @@
+import type { SeminarReviewRequest, SeminarReviewResponse } from '../types/seminarReview';
+import { userInstance } from './userInstance';
+
+export const postSeminarReview = async ({
+  strength,
+  improvement,
+  nextTopic,
+  score,
+  isPublic,
+}: SeminarReviewRequest): Promise<SeminarReviewResponse> => {
+  const res = await userInstance.post<SeminarReviewResponse>('/user/live/review', {
+    strength,
+    improvement,
+    nextTopic,
+    score,
+    isPublic,
+  });
+  return res.data;
+};

--- a/src/components/Seminar/SeminarReviewForm.tsx
+++ b/src/components/Seminar/SeminarReviewForm.tsx
@@ -21,7 +21,7 @@ const SeminarReviewForm = ({ values, onChange }: ReviewFormProps) => {
           <div className="text-[20px] font-extrabold text-gradient">*</div>
         </div>
         <SeminarReviewInput
-          placeholder="ex. 000 부분이 유익했어요, 진로 설계에 도움이 되었어요, ..."
+          placeholder="이번 회차 데브톡 세미나에 대해 좋았던 점을 자유롭게 입력해주세요."
           input={strength}
           onChange={(value) => onChange('strength', value)}
         />
@@ -31,7 +31,7 @@ const SeminarReviewForm = ({ values, onChange }: ReviewFormProps) => {
         <div className="heading-3-semibold text-white ">세미나의 아쉬웠던 점을 남겨주세요</div>
 
         <SeminarReviewInput
-          placeholder="ex. 강의실이 추웠어요, 주제가 어려웠어요, ..."
+          placeholder="이번 회차 데브톡 세미나에 대해 아쉬웠던 점을 자유롭게 입력해주세요."
           input={improvement}
           onChange={(value) => onChange('improvement', value)}
         />
@@ -41,7 +41,7 @@ const SeminarReviewForm = ({ values, onChange }: ReviewFormProps) => {
         <div className="heading-3-semibold text-white ">다음 회차에서 듣고 싶은 주제가 있나요?</div>
 
         <SeminarReviewInput
-          placeholder="ex. 인공지능, 보안, 게임, 커리어, 이력서, ..."
+          placeholder="다음 회차 데브톡 세미나에서 다뤘으면 하는 주제가 있다면 자유롭게 입력해주세요."
           input={nextTopic}
           onChange={(value) => onChange('nextTopic', value)}
         />

--- a/src/components/Seminar/SeminarReviewInput.tsx
+++ b/src/components/Seminar/SeminarReviewInput.tsx
@@ -10,14 +10,20 @@ const SeminarReviewInput = ({ placeholder, input, onChange }: SeminarReviewInput
   };
 
   return (
-    <>
+    <div className="relative w-[335px] h-[174px]">
       <textarea
-        className="w-[335px] h-[149px] p-16 rounded-8 bg-grey-800 text-grey-300 body-1-medium outline-none resize-none required"
+        className="w-full h-full p-16 rounded-8 bg-grey-800 
+        text-grey-50 placeholder:text-grey-300 whitespace-pre-wrap break-keep body-1-medium
+        outline-none border border-transparent focus:border-grey-300 resize-none required"
         placeholder={placeholder}
         value={input}
         onChange={handleReviewChange}
+        maxLength={80}
       />
-    </>
+      <span className="absolute right-[16px] bottom-[16px] text-grey-400 caption-medium">
+        최대 80자(공백 포함)
+      </span>
+    </div>
   );
 };
 

--- a/src/pages/user/seminar/Review.tsx
+++ b/src/pages/user/seminar/Review.tsx
@@ -2,9 +2,12 @@ import { useState } from 'react';
 import BackButton from '../../../components/Button/BackButton';
 import { Button } from '../../../components/Button/Button';
 import ReviewRating from '../../../components/Seminar/ReviewRating';
-import SeminarReviewFrom from '../../../components/Seminar/SeminarReviewForm';
+import SeminarReviewForm from '../../../components/Seminar/SeminarReviewForm';
 import emptybox from '../../../assets/icons/components/SeminarApply/emptybox.svg';
 import checkbox from '../../../assets/icons/components/SeminarApply/checkbox.svg';
+import { useMutation } from '@tanstack/react-query';
+import { postSeminarReview } from '../../../apis/seminarReview';
+import LoadingSpinner from '../../../components/common/LoadingSpinner';
 
 type ReviewValues = {
   strength: string;
@@ -14,7 +17,10 @@ type ReviewValues = {
 
 const Review = () => {
   //별점
-  const [rating, setRating] = useState(0);
+  const [score, setScore] = useState(0);
+
+  //비공개 여부
+  const [isPublic, setIsPublic] = useState(true);
 
   //리뷰
   const [values, setValues] = useState<ReviewValues>({
@@ -24,20 +30,38 @@ const Review = () => {
   });
   const { strength, improvement, nextTopic } = values;
 
-  //비공개 여부
-  const [isPublic, setIsPublic] = useState(false);
-
   //모든 칸 입력 확인
   const isAllFilled =
-    strength.trim() !== '' && improvement.trim() !== '' && nextTopic.trim() !== '' && rating !== 0;
+    strength.trim() !== '' && improvement.trim() !== '' && nextTopic.trim() !== '' && score !== 0;
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: postSeminarReview,
+    onSuccess: () => {
+      alert('소중한 후기 감사합니다!');
+      setValues({
+        strength: '',
+        improvement: '',
+        nextTopic: '',
+      });
+      setScore(0);
+      setIsPublic(true);
+    },
+    onError: () => {
+      alert('후기 제출에 실패했습니다. 다시 시도해주세요.');
+    },
+  });
 
   //리뷰 제출 함수
   function handleSubmit() {
+    if (isPending) return;
     if (!isAllFilled) return;
-
-    console.log('제출 리뷰', values);
-    console.log('제출 별점', rating);
-    console.log('비공개 여부', isPublic);
+    mutate({
+      strength,
+      improvement,
+      nextTopic,
+      score,
+      isPublic,
+    });
   }
 
   //작성한 리뷰 받아오는 함수
@@ -59,17 +83,17 @@ const Review = () => {
       <div className="w-[375px] flex flex-col gap-48">
         {/**별점 매기기 */}
         <div className="w-[375px] h-[112px] flex flex-col gap-28 items-center justify-center">
-          <div className="w-full px-20 gap-4 text-white heading-2-bold">
+          <div className="w-full px-20 text-white heading-2-bold">
             세미나에 대한 후기를 남겨주세요!
           </div>
           <div className="w-full h-[50px] flex flex-row justify-center">
-            <ReviewRating rating={rating} onChange={setRating} />
+            <ReviewRating rating={score} onChange={setScore} />
           </div>
         </div>
 
         {/**리뷰 작성 폼 */}
         <div className="w-[375px] h-[863px] flex flex-col items-center gap-40">
-          <SeminarReviewFrom values={values} onChange={handleChange} />
+          <SeminarReviewForm values={values} onChange={handleChange} />
 
           <div className="w-[335px] h-[169px] flex flex-col gap-32">
             {/**비공개 여부 선택 */}
@@ -80,19 +104,17 @@ const Review = () => {
               </div>
               <div className="w-full h-[24px] flex flex-row gap-8 px-8">
                 <div className="text-white body-1-medium">비공개 요청</div>
-                {!isPublic ? (
+                {isPublic ? (
                   <img
                     src={emptybox}
-                    alt=""
                     className="w-[24px] h-[24px] cursor-pointer"
-                    onClick={() => setIsPublic(true)}
+                    onClick={() => setIsPublic(false)}
                   />
                 ) : (
                   <img
                     src={checkbox}
-                    alt=""
                     className="w-[24px] h-[24px] cursor-pointer"
-                    onClick={() => setIsPublic(false)}
+                    onClick={() => setIsPublic(true)}
                   />
                 )}
               </div>
@@ -100,11 +122,16 @@ const Review = () => {
 
             {/**제출 버튼 */}
             <Button
-              variant={!isAllFilled ? 'disabled' : 'default'}
+              variant={!isAllFilled || isPending ? 'disabled' : 'default'}
               text="후기 제출하기"
               onClick={handleSubmit}
             />
           </div>
+          {isPending && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+              <LoadingSpinner />
+            </div>
+          )}
         </div>
         <div className="h-[91px]"></div>
       </div>

--- a/src/types/seminarReview.ts
+++ b/src/types/seminarReview.ts
@@ -1,0 +1,16 @@
+import type { CommonResponse } from './common';
+
+export interface SeminarReview {
+  reviewId: number;
+  studentNum: string;
+  seminarNum: number;
+}
+export type SeminarReviewResponse = CommonResponse<SeminarReview>;
+
+export type SeminarReviewRequest = {
+  strength: string;
+  improvement: string;
+  nextTopic: string;
+  score: number;
+  isPublic: boolean;
+};


### PR DESCRIPTION
## 🧾 관련 이슈
close : #169 


## 🔍 구현한 내용
세미나 리뷰 작성 api를 연결했습니다


## 📸 스크린샷(선택사항)
https://github.com/user-attachments/assets/f2bdb93b-8dce-4a8f-9966-5bb018389940



## 🙌 리뷰어에게
* /seminar/review 페이지에서 확인 가능합니다!
* 아직 사용자 인증 페이지 구현이 안 돼서 스웨거에서 토큰 발급 받으신 후 직접 localstorage에 userAccessToken에 넣으셔서 테스트 해봐야합니다.. ㅠㅠ
* 리뷰 제출 후에 다른 페이지로 리다이렉트 되거나 해야하는 내용이 없어서 제출 후에는 폼 내용 지운 후 다른 페이지로 리다이렉트 하는 기능은 넣지 않았습니다 홈이나 다른 페이지로 가는 게 좋을 것 같다면 의견 주시면 감사하겠습니다!