### PR TITLE
[FEAT] 세션ID 개수만큼 SpeakerInfo 카드 렌더링

### DIFF
--- a/src/pages/user/seminar/ApplyInfo.tsx
+++ b/src/pages/user/seminar/ApplyInfo.tsx
@@ -24,6 +24,7 @@ const ApplyInfo = () => {
     place: string;
     startDate: string;
     endDate: string;
+    sessionIds: number[];
   } | null>(null);
   const { setSeminarId } = useApplyFlow();
   const setOnceRef = useRef(false); // StrictMode 중복세팅 방지
@@ -86,7 +87,7 @@ const ApplyInfo = () => {
 
   if (!seminarData) return <LoadingSpinner />;
 
-  const { seminarNum, seminarDate, place } = seminarData;
+  const { seminarNum, seminarDate, place, sessionIds } = seminarData;
 
   return (
     <div className="flex flex-col gap-16 justify-center items-center mb-64">
@@ -110,8 +111,9 @@ const ApplyInfo = () => {
                   </div>
                 </div>
                 <div className="flex flex-col gap-12">
-                  <SpeakerInfo />
-                  <SpeakerInfo />
+                  {(sessionIds ?? []).map((_, idx) => (
+                    <SpeakerInfo key={idx} />
+                  ))}
                 </div>
               </div>
 


### PR DESCRIPTION
## 🧾 관련 이슈
close : #201 


## 🔍 구현한 내용
- 현재 세션 개수대로 우선 연사 카드를 렌더링 했습니다.



## 📸 스크린샷(선택사항)
- 현재 1번 세미나는 고유한 sessionId가 4개여서, 다음과 같이 4명의 연사 카드를 보여주도록 했습니다.
<img width="440" height="902" alt="image" src="https://github.com/user-attachments/assets/729596ed-7234-41ca-8900-b32de9d6e15d" />





## 🙌 리뷰어에게
- **해당 세미나 연사 리스트 조회 api**는 2차 개발 예정이셔서 우선 카드 하나로 개수 맞게 보여주도록 코딩했습니다.