### PR TITLE
[FEAT] 홈 노출 회차 홈 UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,14 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './routes';
 import './App.css';
+import { ShowSeminarProvider } from './contexts/ShowSeminarContext';
 
 function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <ShowSeminarProvider>
+      <RouterProvider router={router} />
+    </ShowSeminarProvider>
+  );
 }
 
 export default App;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,17 +3,11 @@ type ButtonProps = {
   text: string;
   onClick?: () => void;
   className?: string;
-  seminarId?: number;
 };
 
-export const Button = ({
-  variant = 'default',
-  text,
-  onClick,
-  className,
-  seminarId,
-}: ButtonProps) => {
+export const Button = ({ variant = 'default', text, onClick, className }: ButtonProps) => {
   const baseStyle = 'w-[335px] h-[48px] rounded-80 subhead-1-semibold cursor-pointer';
+
   const variantStyles = {
     home: 'button-gradient text-white',
     default: 'graphic-gradient-light text-black',
@@ -21,12 +15,13 @@ export const Button = ({
     disabled: 'bg-grey-700 text-grey-500',
     custom: '',
   };
+
   return (
     <button
       className={`${baseStyle} ${variantStyles[variant]} ${className ?? ''}`}
       onClick={onClick}
     >
-      {seminarId ? `${seminarId}${text}` : text}
+      {text}
     </button>
   );
 };

--- a/src/components/common/Cta.tsx
+++ b/src/components/common/Cta.tsx
@@ -1,3 +1,4 @@
+import { useShowSeminar } from '../../contexts/ShowSeminarContext';
 import { useGetUserSeminar } from '../../hooks/userMainPage/useSeminar';
 import { Button } from '../Button/Button';
 
@@ -9,8 +10,8 @@ type CtaProps = {
 };
 
 const Cta = ({ bodyText, buttonText, onClick, isActive }: CtaProps) => {
-  const seminarId = 1;
-  const { data: seminar } = useGetUserSeminar(seminarId);
+  const { seminarId } = useShowSeminar();
+  const { data: seminar } = useGetUserSeminar(seminarId ?? 1);
 
   const extractDate = (dateString?: string) => dateString?.split(' ')[0] ?? '';
 
@@ -32,7 +33,7 @@ const Cta = ({ bodyText, buttonText, onClick, isActive }: CtaProps) => {
           </div>
         </div>
       )}
-      <Button variant="home" text={buttonText} onClick={onClick} seminarId={seminarId} />
+      <Button variant="home" text={buttonText} onClick={onClick} />
     </div>
   );
 };

--- a/src/components/common/SeminarPoster.tsx
+++ b/src/components/common/SeminarPoster.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useGetUserSeminar } from '../../hooks/userMainPage/useSeminar';
 import LoadingSpinner from './LoadingSpinner';
+import { useShowSeminar } from '../../contexts/ShowSeminarContext';
 
 const SeminarPoster = () => {
-  const seminarId = 1;
-  const { data: seminar, isLoading } = useGetUserSeminar(seminarId);
+  const { seminarId, seminarNum } = useShowSeminar();
+  const { data: seminar, isLoading } = useGetUserSeminar(seminarId ?? 1);
   const [showText, setShowText] = useState(false);
 
   useEffect(() => {
@@ -35,7 +36,7 @@ const SeminarPoster = () => {
       {showText && (
         <div className="absolute top-0 pt-32 pl-20 flex flex-col justify-center w-[335px] h-[196px]">
           <div className="flex flex-col gap-4">
-            <p className="text-grey-50 subhead-2-medium">{seminar?.result?.seminarNum}회차</p>
+            <p className="text-grey-50 subhead-2-medium">{seminarNum}회차</p>
             <p className="heading-1-bold text-gradient">{seminar?.result?.topic}</p>
           </div>
 

--- a/src/contexts/ShowSeminarContext.tsx
+++ b/src/contexts/ShowSeminarContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { getShowSeminar } from '../apis/ShowSeminar/userShowSeminar';
+import type { ShowSeminarResult } from '../types/ShowSeminar/userShowSeminar';
+
+interface ShowSeminarContextType extends ShowSeminarResult {
+  isLoading: boolean;
+}
+
+const ShowSeminarContext = createContext<ShowSeminarContextType | undefined>(undefined);
+
+export const ShowSeminarProvider = ({ children }: { children: React.ReactNode }) => {
+  const [seminar, setSeminar] = useState<ShowSeminarContextType>({
+    seminarId: null,
+    seminarNum: null,
+    applicantActivate: false,
+    liveActivate: false,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const res = await getShowSeminar();
+        if (res?.isSuccess && res.result) {
+          setSeminar({ ...res.result, isLoading: false });
+        } else {
+          setSeminar((prev) => ({ ...prev, isLoading: false }));
+        }
+      } catch {
+        setSeminar((prev) => ({ ...prev, isLoading: false }));
+      }
+    };
+    fetch();
+  }, []);
+
+  return <ShowSeminarContext.Provider value={seminar}>{children}</ShowSeminarContext.Provider>;
+};
+
+export const useShowSeminar = () => {
+  const context = useContext(ShowSeminarContext);
+  if (!context) throw new Error('useShowSeminar must be used inside ShowSeminarProvider');
+  return context;
+};

--- a/src/pages/user/home/Home.tsx
+++ b/src/pages/user/home/Home.tsx
@@ -16,27 +16,13 @@ import { LectureCardSession } from '../../../components/LectureCard/LectureCardS
 import { useNavigate } from 'react-router-dom';
 import InfiniteCarousel from '../../../components/common/InfiniteCarousel';
 import { useEffect, useRef, useState } from 'react';
-
-// 임시 하드코딩
-type SeminarInfo = {
-  activeStartDate: string;
-  activeEndDate: string;
-};
-
-const seminar: SeminarInfo = {
-  activeStartDate: '2025-10-05T23:53:51.927Z',
-  activeEndDate: '2025-10-08T23:53:51.927Z',
-};
+import { useShowSeminar } from '../../../contexts/ShowSeminarContext';
 
 const Home = () => {
   const navigate = useNavigate();
   const exSeminarref = useRef<HTMLDivElement | null>(null);
   const [hideCTA, setHideCTA] = useState(false);
   const [hamburgerOpen, setHamburgerOpen] = useState(false);
-  const seminarId = 1;
-
-  const now = new Date();
-  const isActive = now > new Date(seminar.activeStartDate) && now < new Date(seminar.activeEndDate);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -63,6 +49,40 @@ const Home = () => {
     };
   }, []);
 
+  const { seminarId, seminarNum, liveActivate, applicantActivate, isLoading } = useShowSeminar();
+
+  let ctaElement = null;
+  if (applicantActivate && liveActivate) {
+    ctaElement = (
+      <Cta
+        bodyText="지금 바로 입장해 주세요!"
+        buttonText={`${seminarNum ?? ''}회차 세미나 입장하기`}
+        onClick={() => navigate('seminar/live/verification')}
+        isActive
+      />
+    );
+  } else if (applicantActivate && !liveActivate) {
+    ctaElement = (
+      <Cta
+        bodyText="데브톡에 빠져보세요!"
+        buttonText={`${seminarNum ?? ''}회차 세미나 신청하기`}
+        onClick={() => navigate('seminar/apply-info')}
+        isActive={false}
+      />
+    );
+  } else if (!applicantActivate && liveActivate) {
+    ctaElement = (
+      <Cta
+        bodyText="지금 바로 입장해 주세요!"
+        buttonText={`${seminarNum ?? ''}회차 세미나 입장하기`}
+        onClick={() => navigate('seminar/live/verification')}
+        isActive
+      />
+    );
+  } else {
+    ctaElement = null;
+  }
+
   return (
     <>
       <div>
@@ -72,24 +92,9 @@ const Home = () => {
             <SeminarPoster />
           </div>
 
-          {!hideCTA && !hamburgerOpen && (
-            <div className="fixed bottom-0 w-full z-50">
-              {isActive ? (
-                <Cta
-                  bodyText="지금 바로 입장해 주세요!"
-                  buttonText="회차 세미나 입장하기"
-                  onClick={() => navigate('seminar/live/verification')}
-                  isActive={isActive}
-                />
-              ) : (
-                <Cta
-                  bodyText="데브톡에 빠져보세요!"
-                  buttonText="회차 세미나 신청하기"
-                  onClick={() => navigate('/seminar/apply-info')}
-                  isActive={isActive}
-                />
-              )}
-            </div>
+          {/* CTA */}
+          {!hideCTA && !hamburgerOpen && !isLoading && ctaElement && (
+            <div className="fixed bottom-0 w-full z-50">{ctaElement}</div>
           )}
 
           {/* 강연 소개 카드 */}
@@ -100,16 +105,16 @@ const Home = () => {
 
             <div className="flex flex-col snap-center pb-[80px]">
               <Carousel>
-                <LectureCardMain seminarId={seminarId} index={0} />
-                <LectureCardSpeaker seminarId={seminarId} index={0} />
-                <LectureCardSession seminarId={seminarId} index={0} />
+                <LectureCardMain seminarId={seminarId ?? 0} index={0} />
+                <LectureCardSpeaker seminarId={seminarId ?? 0} index={0} />
+                <LectureCardSession seminarId={seminarId ?? 0} index={0} />
               </Carousel>
             </div>
             <div className="flex flex-col snap-center">
               <Carousel>
-                <LectureCardMain seminarId={seminarId} index={1} />
-                <LectureCardSpeaker seminarId={seminarId} index={1} />
-                <LectureCardSession seminarId={seminarId} index={1} />
+                <LectureCardMain seminarId={seminarId ?? 0} index={1} />
+                <LectureCardSpeaker seminarId={seminarId ?? 0} index={1} />
+                <LectureCardSession seminarId={seminarId ?? 0} index={1} />
               </Carousel>
             </div>
           </div>
@@ -193,44 +198,47 @@ const Home = () => {
           </div>
 
           {/* 신청하기 */}
-          {isActive ? (
-            <div className="flex flex-col items-center pt-[120px] px-20 pb-[100px] gap-16">
-              <p className="text-white heading-2-bold">지금 바로 입장하세요!</p>
-              <div className="flex flex-col w-[335px] gap-28">
-                <div className="flex flex-col items-center gap-16">
-                  <img
-                    src={Ticket}
-                    alt="티켓 아이콘"
-                    className="w-[240px] h-[153px] object-cover"
-                  />
+          {!isLoading && (
+            <>
+              {liveActivate ? (
+                <div className="flex flex-col items-center pt-[120px] px-20 pb-[100px] gap-16">
+                  <p className="text-white heading-2-bold">지금 바로 입장하세요!</p>
+                  <div className="flex flex-col w-[335px] gap-28">
+                    <div className="flex flex-col items-center gap-16">
+                      <img
+                        src={Ticket}
+                        alt="티켓 아이콘"
+                        className="w-[240px] h-[153px] object-cover"
+                      />
+                    </div>
+                    <Button
+                      variant="default"
+                      text={`${seminarNum ?? ''}회차 세미나 입장하기`}
+                      onClick={() => navigate('seminar/live/verification')}
+                    />
+                  </div>
                 </div>
-                <Button
-                  variant="default"
-                  text="10회차 세미나 입장하기"
-                  onClick={() => navigate('seminar/live/verification')}
-                />
-              </div>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center pt-[120px] px-20 pb-[100px] gap-16">
-              <p className="text-white heading-2-bold">지금 바로 신청하세요!</p>
-              <div className="flex flex-col w-[335px] gap-28">
-                <div className="flex flex-col items-center gap-16">
-                  <img
-                    src={Timer}
-                    alt="타이머 아이콘"
-                    className="w-[240px] h-[153px] object-cover"
-                  />
+              ) : applicantActivate ? (
+                <div className="flex flex-col items-center pt-[120px] px-20 pb-[100px] gap-16">
+                  <p className="text-white heading-2-bold">지금 바로 신청하세요!</p>
+                  <div className="flex flex-col w-[335px] gap-28">
+                    <div className="flex flex-col items-center gap-16">
+                      <img
+                        src={Timer}
+                        alt="타이머 아이콘"
+                        className="w-[240px] h-[153px] object-cover"
+                      />
+                    </div>
+                    <Button
+                      variant="default"
+                      text={`${seminarNum ?? ''}회차 세미나 신청하기`}
+                      onClick={() => navigate('/seminar/apply-info')}
+                    />
+                  </div>
                 </div>
-                <Button
-                  variant="default"
-                  text="10회차 세미나 신청하기"
-                  onClick={() => navigate('/seminar/apply-info')}
-                />
-              </div>
-            </div>
+              ) : null}
+            </>
           )}
-
           <div className="h-[122px] snap-start">
             <Footer />
           </div>

--- a/src/pages/user/seminar/Live.tsx
+++ b/src/pages/user/seminar/Live.tsx
@@ -5,6 +5,7 @@ import { useSeminarAttend } from '../../../hooks/SeminarLive/useSeminarAttend';
 import { useNavigate } from 'react-router-dom';
 import LoadingSpinner from '../../../components/common/LoadingSpinner';
 import { useState } from 'react';
+import { useShowSeminar } from '../../../contexts/ShowSeminarContext';
 
 const Live = () => {
   const { mutate, isPending } = useSeminarAttend();
@@ -23,13 +24,14 @@ const Live = () => {
   };
 
   const [hamburgerOpen, setHamburgerOpen] = useState(false);
+  const { seminarNum } = useShowSeminar();
 
   return (
     <>
       <Header hamburgerOpen={hamburgerOpen} setHamburgerOpen={setHamburgerOpen} />
       {isPending && <LoadingSpinner />}
       <div className="flex flex-col pt-28 px-20 gap-24 pb-[10px]">
-        <p className="text-white heading-2-bold">제 10회 Devtalk Seminar</p>
+        <p className="text-white heading-2-bold">제 {seminarNum}회 Devtalk Seminar</p>
         <img src={seminarLive} alt="graphic" className="w-[335px] h-[435px]" />
       </div>
       <div className="flex px-20 pt-20 pb-[89px]">


### PR DESCRIPTION
## 🧾 관련 이슈
close : #214 


## 🔍 구현한 내용

- 어드민에서 홈 화면 신청 활성화/ Live 활성화에 따른 홈, 세미나 라이브 UI를 수정했습니다!
- 아래 사진과 같은 로직으로 작성했습니다
<img width="721" height="297" alt="image" src="https://github.com/user-attachments/assets/4dd00e34-9c5b-49ff-af6b-6ee035a4c8ba" />



## 📸 스크린샷(선택사항)



## 🙌 리뷰어에게
