### PR TITLE
[REFACTOR] 세미나 신청폼 사전 질문란 UI 수정

### DIFF
--- a/src/components/SeminarApply/SpeakerCard.tsx
+++ b/src/components/SeminarApply/SpeakerCard.tsx
@@ -10,6 +10,11 @@ type SpeakerCardProps = {
 };
 
 const SpeakerCard = ({ name, title, organization, description, profileUrl }: SpeakerCardProps) => {
+  // %~% 텍스트 <span>으로 변환
+  const highlightDescription = (text: string) => {
+    return text.replace(/%([^%]+)%/g, '<span class="text-gradient">$1</span>');
+  };
+
   return (
     <div className="flex items-center justify-center">
       <div className="flex flex-col w-[335px] h-[622px] rounded-12 bg-grey-800 gap-5 justify-center">
@@ -50,9 +55,10 @@ const SpeakerCard = ({ name, title, organization, description, profileUrl }: Spe
           <div className="heading-3-semibold text-center text-white w-[267px] break-all">
             {title}
           </div>
-          <div className="body-2-medium text-grey-200 w-[295px] whitespace-pre-wrap">
-            {description}
-          </div>
+          <div
+            className="body-2-medium text-grey-200 w-[295px] whitespace-pre-line"
+            dangerouslySetInnerHTML={{ __html: highlightDescription(description ?? '') }}
+          ></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🧾 관련 이슈
close : #230 


## 🔍 구현한 내용
- 세션 제목과 내용 부분의 줄바꿈을 수정했습니다.
- 또한 어드민에서 세션 입력 시 `%%` 사이에 있는 내용은 `text-gradient` 처리했습니다.



## 📸 스크린샷(선택사항)
- 신청폼의 사전 질문란 부분입니다.
<img width="420" height="722" alt="스크린샷 2025-11-01 195522" src="https://github.com/user-attachments/assets/f19117cf-4fca-4515-a6af-c62a89c4f72e" />





## 🙌 리뷰어에게
