### PR TITLE
[FEAT] 홈 화면 후기 카드 조회

### DIFF
--- a/src/components/common/InfiniteCarousel.tsx
+++ b/src/components/common/InfiniteCarousel.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 
-export default function InfiniteCarousel({
-  children,
-}: {
-  children: React.ReactElement[];
-}) {
+interface InfiniteCarouselProps {
+  children: ReactNode;
+}
+
+export default function InfiniteCarousel({ children }: InfiniteCarouselProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(true);
@@ -12,8 +12,10 @@ export default function InfiniteCarousel({
   const REVIEWCARD_WIDTH = 335;
   const INTERVAL = 4000;
 
+  const childrenArray = Array.isArray(children) ? children : [children];
+
   // children 배열 뒤에 첫 번째 요소 복제
-  const slides = [...children, children[0]];
+  const slides = [...childrenArray, childrenArray[0]];
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -40,19 +42,16 @@ export default function InfiniteCarousel({
         className="flex"
         style={{
           gap: `8px`,
-          transform: `translateX(calc(${
-            -(currentIndex * (REVIEWCARD_WIDTH + 8))
-          }px + (50% - ${REVIEWCARD_WIDTH / 2}px)))`,
-          transition: isTransitioning ? "transform 0.5s ease-out" : "none",
+          transform: `translateX(calc(${-(
+            currentIndex *
+            (REVIEWCARD_WIDTH + 8)
+          )}px + (50% - ${REVIEWCARD_WIDTH / 2}px)))`,
+          transition: isTransitioning ? 'transform 0.5s ease-out' : 'none',
         }}
         onTransitionEnd={handleTransitionEnd}
       >
         {slides.map((slide, i) => (
-          <div
-            key={i}
-            className="flex-shrink-0"
-            style={{ width: REVIEWCARD_WIDTH }}
-          >
+          <div key={i} className="flex-shrink-0" style={{ width: REVIEWCARD_WIDTH }}>
             {slide}
           </div>
         ))}

--- a/src/pages/user/home/Home.tsx
+++ b/src/pages/user/home/Home.tsx
@@ -18,12 +18,9 @@ import InfiniteCarousel from '../../../components/common/InfiniteCarousel';
 import { useEffect, useRef, useState } from 'react';
 import { useShowSeminar } from '../../../contexts/ShowSeminarContext';
 import BackgroundVideo from '../../../components/common/BackgroundVideo';
-<<<<<<< HEAD
 import { useHomeReviews } from '../../../hooks/HomeManage/useHomeReview';
 import { useSeminarReviews } from '../../../hooks/SeminarManage/data/useSeminarReviews';
-=======
 import ComingSoon from '../../../components/common/ComingSoon';
->>>>>>> 26818c592d2961f48e85d922090c997c059d57d2
 
 const Home = () => {
   const navigate = useNavigate();
@@ -65,7 +62,6 @@ const Home = () => {
   // 노출 회차 정보
   const { seminarId, seminarNum, liveActivate, applicantActivate, isLoading } = useShowSeminar();
   const { data } = useHomeReviews();
-  const { data: reviewListData } = useSeminarReviews(seminarId ?? undefined);
 
   let ctaElement = null;
   if (applicantActivate && liveActivate && seminarId) {
@@ -173,9 +169,10 @@ const Home = () => {
             <p className="text-white heading-2-bold">학우들의 후기</p>
             <div className="-mx-20">
               <InfiniteCarousel>
-                {data?.map((review, idx) => (
+                {data?.result?.map((review) => (
                   <ReviewCard
-                    session={reviewListData?.result?.seminarNum}
+                    key={review.reviewId}
+                    session={review.seminarNum}
                     rating={review.rating}
                     content={review.content}
                   />

--- a/src/types/HomeManage/homeReview.ts
+++ b/src/types/HomeManage/homeReview.ts
@@ -9,6 +9,7 @@ export interface Review {
   department: string;
   grade: string;
   nextTopic: string;
+  seminarNum: number;
   order: number;
   createdAt: string;
 }


### PR DESCRIPTION
## 🧾 관련 이슈
close : #249 


## 🔍 구현한 내용

- 홈 화면 내 후기 카드 조회를 구현했습니다. 



## 📸 스크린샷(선택사항)





## 🙌 리뷰어에게
<img width="1829" height="716" alt="image" src="https://github.com/user-attachments/assets/db4c1099-fa06-4bfd-8211-3c8096cc38e8" />

- 6, 7, 8, 9회차 중 일부 후기들을 공개로 설정해두었습니다!
